### PR TITLE
adds config dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ If your MATSim outputs use default names and are in the same directory, you may 
 
 ### Configuration dry run
 
-`elara run` supports some optional flags and arguments which can be discovered with `elara run --help`, most useful is `elara run -d` (or `elara run --dry`) which can be use to test a config without providing valid inputs or unertaking the processing.
+`elara run` supports some optional flags and arguments which can be discovered with `elara run --help`, most useful is `elara run -d` (or `elara run --dry`) which can be use to test a config without providing valid inputs or undertaking the processing.
 
 ## Command Line Reference
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ These are processed by streaming (in order) through all output events from simul
 Currently supported handlers include:
 
 * ``link_vehicle_counts``: Produce link volume counts and volume capacity ratios by time slice. Counts **vehicles** entering link (PT vehicles counted once).
-* ``link_vehicle_capacity``: Produce link capacity counts by time slice for understanding PT crowding. Sums the vehicle capacities of all **vehicles** entering link for the particular PT mode. 
+* ``link_vehicle_capacity``: Produce link capacity counts by time slice for understanding PT crowding. Sums the vehicle capacities of all **vehicles** entering link for the particular PT mode.
 * ``link_passenger_counts``: Produce link passenger counts by time slice. Counts **agents** entering link.
 * ``link_vehicle_speeds``: Produce average vehicle speeds across link (in kilometers per hour).
 * ``route_passenger_counts``: (WIP) Produce vehicle occupancies by transit routes.
@@ -209,6 +209,10 @@ You can run this config on some toy data: `elara run example_configs/config.toml
 
 If your MATSim outputs use default names and are in the same directory, you may optionally pass the path of this directory as single argument to `[inputs]` using, e.g. `inputs_directory = "./tests/test_fixtures/"`. **NB:** If using the ``toll_log`` plan handler, you must still provide the `road_pricing` path separately.
 
+### Configuration dry run
+
+`elara run` supports some optional flags and arguments which can be discovered with `elara run --help`, most useful is `elara run -d` (or `elara run --dry`) which can be use to test a config without providing valid inputs or unertaking the processing.
+
 ## Command Line Reference
 
 Elara can also be more generally used via the CLI to process individual outputs. Used in this manner the CLI should be pretty discoverable, once installed, try the command `elara` in your terminal to find out about the available options:
@@ -259,10 +263,10 @@ Options:
   --help                      Show this message and exit.
 ```
 
-*Note that defaults will not always be suitable for your scenario. `-s` `--scale_factor` in 
+*Note that defaults will not always be suitable for your scenario. `-s` `--scale_factor` in
 particular, should be updated accordingly.*
 
-*Similarly, note that the CLI assumes inputs will have standard (at the time of writing) MATSim 
+*Similarly, note that the CLI assumes inputs will have standard (at the time of writing) MATSim
 names, ie `output_plans.xml.gz`, `output_personAttributes.xml.gz`, `output_config.xml` and so on.*
 
 ### Example CLI Usage
@@ -275,10 +279,10 @@ or, more succinctly:
 
 `elara post-processors vkt car -i ~/DIFFERENT/DATA/LOCATION`
 
-To reduce **volume counts for cars and buses** using a New Zealand projection (2113). The scenario was 
+To reduce **volume counts for cars and buses** using a New Zealand projection (2113). The scenario was
 a 1% sample. You'd like to prefix the outputs as 'nz_test' in a new directory '~/Data/nz_test':
 
-`elara event-handlers volume-counts car bus -epsg EPSG:2113 -scale_factor .01 -name nz_test 
+`elara event-handlers volume-counts car bus -epsg EPSG:2113 -scale_factor .01 -name nz_test
 -outputs_path ~/Data/nz_test`
 
 or, much more succinctly:
@@ -309,7 +313,7 @@ The name of the scenario being processed.
 
 **time_periods** *integer* *(required)*
 
-The number of time slices used to split a 24-hour period for the purposes of reporting. A value 
+The number of time slices used to split a 24-hour period for the purposes of reporting. A value
 of ``24`` will produce summary metrics for each our of the day. Similarly, a value of ``96`` will produce 15-minute summaries.
 
 **scale_factor** *float* *(required)*
@@ -416,7 +420,7 @@ plan_summary = ["all"]
 trip_duration_breakdown = ["all"]
 ```
 
-The associated list attached to each handler allows specification of which modes of transport 
+The associated list attached to each handler allows specification of which modes of transport
 should be processed using that handler.
 
 * modes should be supplied as a list eg ``["car", "bus", "train", ...]`` or just ``["car"]``.
@@ -511,12 +515,12 @@ Elara assumes your MATSim run is configured to output agents' "experienced" plan
 ```{.toml}
 [scenario]
 ...
-using_experienced_plans = false 
+using_experienced_plans = false
 ```
 
 This option is set to `true` by default, and does not need to be included it in the config, although you may set it explicitly if you wish.
 
-When using MATSim "experienced" plans from versions 12 and up you will find that these (currently) do not include the person attributes. In turn, this prevents elara from providing outputs grouped by person attributes (ie those that use the `groupby_person_attributes` option). 
+When using MATSim "experienced" plans from versions 12 and up you will find that these (currently) do not include the person attributes. In turn, this prevents elara from providing outputs grouped by person attributes (ie those that use the `groupby_person_attributes` option).
 
 If such outputs are required when using experienced plans, provide the standard MATSim 'output_plans' as the attributes input:
 
@@ -550,7 +554,7 @@ To generate XML & HTML coverage reports to `reports/coverage`:
 
 ## Debug
 
-Logging level can be set in the config or via the cli, or otherwise defaults to False (INFO). We 
+Logging level can be set in the config or via the cli, or otherwise defaults to False (INFO). We
 currently support the following levels: DEBUG, INFO.
 
 Note that the configured or default logging level can be overwritten to debug using an env variable:
@@ -572,7 +576,7 @@ Elara defines a graph of connected `WorkStations`, each responsible for building
 Elara uses this **DAG** to provide:
 
 * **Minimal** dependency processing
-* **Early validation** of all intermediate requirements 
+* **Early validation** of all intermediate requirements
 * **Early Failure**/Ordering
 
 Elara does this by traversing the DAG in three stages:
@@ -591,13 +595,13 @@ Sometimes:
 
 ## Adding Features
 
-**NOTE**: Pushing code to this repository is temporarily restricted while we undergo some spring cleaning during April/May 2022. If you wish to contribute code, please contact one of the owners for permisison. 
+**NOTE**: Pushing code to this repository is temporarily restricted while we undergo some spring cleaning during April/May 2022. If you wish to contribute code, please contact one of the owners for permisison.
 
 Elara is designed to be extendable, primarily with new tools such as handlers or benchmarks.
 
 Where new tools are new classes that implement some process that fits within the implementation (both in terms of code and also abstractly) of a WorkStation. New tools must be added to the relevant workstations 'roster' of tools (ie `.tools`).
 
-New tool classes must correctly inherit and implement a number of values and methods so that they 
+New tool classes must correctly inherit and implement a number of values and methods so that they
 play well with their respective workstation:
 
 * ``.__init__(self, config, mode)``: Used for early validation of mode and subsequent requirements.

--- a/elara/benchmarking.py
+++ b/elara/benchmarking.py
@@ -1639,12 +1639,12 @@ class PointsCounter(BenchmarkTool):
         bm_results_summary = bm_results_df.groupby('source').sum()
 
         # write results
-        csv_name = '{}_{}_bm.csv'.format(self.config.name, self.name)
+        csv_name = f'{self.name}_bm.csv'
         csv_path = os.path.join('benchmarks', csv_name)
         self.write_csv(bm_results_df, csv_path, write_path=write_path)
 
         # write results
-        csv_name = '{}_{}_bm_summary.csv'.format(self.config.name, self.name)
+        csv_name = 'f{self.name}_bm_summary.csv'
         csv_path = os.path.join('benchmarks', csv_name)
         self.write_csv(bm_results_summary, csv_path, write_path=write_path)
 
@@ -2002,14 +2002,14 @@ class OldModeSharesComparison(BenchmarkTool):
         summary_df.loc[:, 'diff'] = summary_df.model - summary_df.benchmark
 
         # write results
-        csv_name = '{}_modeshare_results.csv'.format(self.config.name)
+        csv_name = 'modeshare_results.csv'
         csv_path = os.path.join('benchmarks', csv_name)
         self.write_csv(summary_df, csv_path, write_path=write_path)
 
         #plot
         summary_df_plot = pd.melt(summary_df.reset_index(), id_vars=['mode'], value_vars = ['benchmark','model'], var_name = 'type', value_name='modeshare')
         bm_results_summary_plot = comparative_column_plots(summary_df_plot)
-        plot_name = '{}_modeshare_results.png'.format(self.config.name)
+        plot_name = 'modeshare_results.png'
         bm_results_summary_plot.save(os.path.join(self.config.output_path,"benchmarks", plot_name), verbose=False)
         plt.close()
 

--- a/elara/event_handlers.py
+++ b/elara/event_handlers.py
@@ -514,7 +514,7 @@ class LinkVehicleCounts(EventHandlerTool):
 
 class LinkVehicleCapacity(EventHandlerTool):
     """
-    Extract capacity for mode per link on given network. 
+    Extract capacity for mode per link on given network.
     """
 
     requirements = [
@@ -525,7 +525,7 @@ class LinkVehicleCapacity(EventHandlerTool):
         'attributes',
     ]
     invalid_modes = ['car']
-    
+
     def __init__(self, config, mode="all", groupby_person_attribute=None, **kwargs) -> None:
         """
         Initiate class, creates results placeholders.
@@ -569,11 +569,11 @@ class LinkVehicleCapacity(EventHandlerTool):
         links = resources['network'].mode_to_links_map.get(self.mode)
         if links is None:
             self.logger.warning(
-                f"""
-                No viable links found for mode:{self.mode} in Network,
-                this may be because the Network modes do not match the configured
-                modes. Elara will continue with all links found in network.
-                """
+f"""
+No viable links found for mode:{self.mode} in Network,
+this may be because the Network modes do not match the configured
+modes. Elara will continue with all links found in network.
+"""
                 )
         else:
             self.logger.debug(f'Selecting links for mode:{self.mode}.')
@@ -660,7 +660,7 @@ class LinkVehicleCapacity(EventHandlerTool):
             totals_df, how="left"
         )
         self.result_dfs[key] = totals_df
-        
+
 
 class LinkVehicleSpeeds(EventHandlerTool):
     """
@@ -713,11 +713,11 @@ class LinkVehicleSpeeds(EventHandlerTool):
         links = resources['network'].mode_to_links_map.get(self.mode)
         if links is None:
             self.logger.warning(
-                f"""
-                No viable links found for mode:{self.mode} in Network,
-                this may be because the Network modes do not match the configured
-                modes. Elara will continue with all links found in network.
-                """
+f"""
+No viable links found for mode:{self.mode} in Network,
+this may be because the Network modes do not match the configured
+modes. Elara will continue with all links found in network.
+"""
                 )
         else:
             self.logger.debug(f'Selecting links for mode:{self.mode}.')
@@ -1007,11 +1007,11 @@ class LinkPassengerCounts(EventHandlerTool):
         links = resources['network'].mode_to_links_map.get(self.mode)
         if links is None:
             self.logger.warning(
-                f"""
-                No viable links found for mode:{self.mode} in Network,
-                this may be because the Network modes do not match the configured
-                modes. Elara will continue with all links found in network.
-                """
+f"""
+No viable links found for mode:{self.mode} in Network,
+this may be because the Network modes do not match the configured
+modes. Elara will continue with all links found in network.
+"""
                 )
         else:
             self.logger.debug(f'Selecting links for mode:{self.mode}.')
@@ -1205,11 +1205,11 @@ class RoutePassengerCounts(EventHandlerTool):
         routes = resources['transit_schedule'].mode_to_routes_map.get(self.mode)
         if routes is None:
             self.logger.warning(
-                f"""
-                No viable routes found for mode:{self.mode} in TransitSchedule,
-                this may be because the Schedule modes do not match the configured
-                modes. Elara will continue with all routes found in schedule.
-                """
+f"""
+No viable routes found for mode:{self.mode} in TransitSchedule,
+this may be because the Schedule modes do not match the configured
+modes. Elara will continue with all routes found in schedule.
+"""
                 )
 
         self.elem_ids, self.elem_indices = self.generate_elem_ids(list(routes))
@@ -1578,11 +1578,11 @@ class StopToStopPassengerCounts(EventHandlerTool):
         viable_stops = resources['transit_schedule'].mode_to_stops_map.get(self.mode)
         if viable_stops is None:
             self.logger.warning(
-                f"""
-                No viable stops found for mode:{self.mode} in TransitSchedule,
-                this may be because the Schedule modes do not match the configured
-                modes. Elara will continue with all stops found in schedule.
-                """
+f"""
+No viable stops found for mode:{self.mode} in TransitSchedule,
+this may be because the Schedule modes do not match the configured
+modes. Elara will continue with all stops found in schedule.
+"""
                 )
         else:
             self.logger.debug(f'Filtering stops for mode:{self.mode}.')
@@ -1823,11 +1823,11 @@ class VehicleStopToStopPassengerCounts(EventHandlerTool):
         viable_stops = resources['transit_schedule'].mode_to_stops_map.get(self.mode)
         if viable_stops is None:
             self.logger.warning(
-                f"""
-                No viable stops found for mode:{self.mode} in TransitSchedule,
-                this may be because the Schedule modes do not match the configured
-                modes. Elara will continue with all stops found in schedule.
-                """
+f"""
+No viable stops found for mode:{self.mode} in TransitSchedule,
+this may be because the Schedule modes do not match the configured
+modes. Elara will continue with all stops found in schedule.
+"""
                 )
         else:
             self.logger.debug(f'Filtering stops for mode:{self.mode}.')

--- a/elara/factory.py
+++ b/elara/factory.py
@@ -462,12 +462,8 @@ class WorkStation:
     def build_helpful_error_string(self, missing: List[str]) -> str:
         """
         Create a useful message for unfound "missing" requirements.
-
-        Args:
-            missing (list): list of missing requirements
-
-        Returns:
-            str: message
+        :param missing: (list) list of missing requirements
+        :return: (str) message
         """
         error_string = ""
         for m in missing:

--- a/elara/main.py
+++ b/elara/main.py
@@ -68,12 +68,16 @@ def run(config_path, path_override, root, output_directory_override, dry_run):
     :param config: Session configuration object
     """
     logger.info('Starting')
+    main(config=config, logger=logger, dry_run=dry_run)
+    logger.info('Done')
+
+
+def main(config, logger, dry_run=False) -> None:
     requirements = define_and_connect_workstations(config, logger)
     if dry_run:
         factory.dry_run_build(requirements)
     else:
         factory.build(requirements)
-    logger.info('Done')
 
 
 def define_and_connect_workstations(config, logger):

--- a/elara/main.py
+++ b/elara/main.py
@@ -23,18 +23,18 @@ def cli():
 
 @cli.command()
 @click.argument("config_path", type=click.Path(exists=True))
-@click.option("--path_override", '-o', default=None)
-@click.option("--root", '-r', default=None)
-@click.option("--output_directory_override", default=None)
-@click.option("--dry_run", "-d", is_flag=True)
-def run(config_path, path_override, root, output_directory_override, dry_run):
+@click.option("--dry", "-d", is_flag=True, help="test run a config file.")
+@click.option("--path_override", '-o', default=None, help="over-ride input path root.")
+@click.option("--root", '-r', default=None, help="over-ride all path roots.")
+@click.option("--output_directory_override", default=None, help="over-ride output directory to new path.")
+def run(config_path, dry, path_override, root, output_directory_override):
     """
     Run Elara using a config.
     :param config_path: Configuration file path
     :param path_override: containing directory to update for [inputs], outputs.path in toml
     :param root: add root to all paths (assumes that paths in config are relative)
-    :param output_directory_override: change output directory
-    :param dry_run: flag to initiate a run test
+    :param output_directory_override: change outputs directory
+    :param dry: flag to initiate a run test
     """
 
     if path_override and root:
@@ -68,7 +68,7 @@ def run(config_path, path_override, root, output_directory_override, dry_run):
     :param config: Session configuration object
     """
     logger.info('Starting')
-    main(config=config, logger=logger, dry_run=dry_run)
+    main(config=config, logger=logger, dry_run=dry)
     logger.info('Done')
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ pytest-xdist==2.5.0
 shapely==1.7.1
 toml==0.10.0
 tqdm==4.40.2
+fuzzywuzzy==0.18.0
+

--- a/scripts/.coveragerc
+++ b/scripts/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-omit = venv/*, tests/*, elara/tool_templates.py, scripts/*
+omit = venv/*, tests/*, elara/tool_templates.py, scripts/*, elara/setup.py
 
 [report]
 fail_under = 86

--- a/tests/test_6_factory_base.py
+++ b/tests/test_6_factory_base.py
@@ -6,7 +6,8 @@ import logging
 
 
 sys.path.append(os.path.abspath('../elara'))
-from elara.factory import WorkStation, Tool, complex_combine_reqs, equals, build, build_graph_depth, combine_reqs, complex_combine_reqs
+from elara.factory import WorkStation, Tool
+from elara.factory import complex_combine_reqs, equals, build, build_graph_depth, combine_reqs, complex_combine_reqs, get_closest
 
 test_dir = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 test_inputs = os.path.join(test_dir, "test_intermediate_data")
@@ -269,7 +270,7 @@ def test_requirements(
         inputs_process.gather_manager_requirements(),
         {'events': {'groupby_person_attributes': {None}, 'modes': {None}}, 'network': {'groupby_person_attributes': {None}, 'modes': {None}}, 'plans': {'groupby_person_attributes': {None}, 'modes': {None}}}
     )
-    assert equals(  
+    assert equals(
         config_paths.gather_manager_requirements(),
         {'events_path': {'groupby_person_attributes': {None}, 'modes': {None}}, 'network_path': {'groupby_person_attributes': {None}, 'modes': {None}}, 'plans_path': {'groupby_person_attributes': {None}, 'modes': {None}}}
     )
@@ -372,3 +373,8 @@ def test_engage_supply_chain(
     assert set(plan_handler_process.resources) == {'mode_share:all:region:'}
     assert set(inputs_process.resources) == {'events', 'network', 'plans'}
     assert set(config_paths.resources) == {'events_path', 'network_path', 'plans_path'}
+
+
+def test_get_closest():
+    assert get_closest("hell", ["hello", ""], limit=3, score=75) == ["hello"]
+    assert len(get_closest("hell", ["hello","help","hella","helli","helm"], limit=3, score=75)) == 3

--- a/tests/test_7_factory.py
+++ b/tests/test_7_factory.py
@@ -604,6 +604,22 @@ def test_convert_to_unique_keys():
     assert keys == ['req1:1', 'req1:2', 'req2:1', 'req3']
 
 
+def test_list_equals():
+    assert factory.list_equals(None, None) == True
+    assert factory.list_equals(None, []) == False
+    assert factory.list_equals([], []) == True
+    assert factory.list_equals([1,2], [1,2]) == True
+    assert factory.list_equals([1,2], [2,1]) == True
+    assert factory.list_equals([1,2,3], [1,2]) == False
+
+
+def test_dict_equals():
+    assert factory.equals({}, {}) == True
+    assert factory.equals({1:[1]}, {1:[1]}) == True
+    assert factory.equals({2:[1]}, {1:[1]}) == False
+    assert factory.equals({1:[1]}, {1:[2]}) == False
+
+
 def test_write_geojson(tmpdir):
     df = pd.DataFrame({1:[1,2,3], 2: [4,5,6]})
     poly = Polygon(((0,0), (1,0), (1,1), (0,1)))
@@ -728,7 +744,7 @@ def test_write_json_tool_no_path(tmpdir):
 def test_write_png_tool(tmpdir):
     df = pd.DataFrame({1:[1,2,3], 2: [4,5,6]})
     ax = df.plot()
-    fig = ax.get_figure()   
+    fig = ax.get_figure()
     tool = factory.Tool(config=None)
     tool.logger = logging.getLogger(__name__)
     tool.write_png(

--- a/tests/test_7_factory.py
+++ b/tests/test_7_factory.py
@@ -772,3 +772,31 @@ def test_write_png_tool(tmpdir):
     )
     path = os.path.join(tmpdir, 'test2.png')
     assert os.path.exists(path)
+
+
+
+def test_build_helpful_error_string_for_events(test_config):
+    """This test is likely to break if more tools are added with 'log' in the name. Sorry"""
+    requirements = RequirementsWorkStation(test_config)
+    event_handlers = EventHandlerWorkStation(test_config)
+
+    requirements.connect(None, [event_handlers])
+    assert requirements.build_helpful_error_string(["log"]) == """
+RequirementsWorkStation workstation cannot find requirement: 'log'.
+\tdid you mean: 'vehicle_departure_log' (EventHandlerWorkStation)
+\tdid you mean: 'vehicle_passenger_log' (EventHandlerWorkStation)
+\tdid you mean: 'vehicle_link_log' (EventHandlerWorkStation)"""
+
+
+
+def test_build_helpful_error_string_for_plans(test_config):
+    """This test is likely to break if more tools are added with 'mode' in the name. Sorry"""
+    requirements = RequirementsWorkStation(test_config)
+    plan_handlers = PlanHandlerWorkStation(test_config)
+
+    requirements.connect(None, [plan_handlers])
+    assert requirements.build_helpful_error_string(["mode"]) == """
+RequirementsWorkStation workstation cannot find requirement: 'mode'.
+\tdid you mean: 'trip_modes' (PlanHandlerWorkStation)
+\tdid you mean: 'trip_activity_modes' (PlanHandlerWorkStation)
+\tdid you mean: 'plan_modes' (PlanHandlerWorkStation)"""


### PR DESCRIPTION
enables a config dry run:

`elara run -d ~/Data/TE/elara_config.toml` or `elara run -dry_run ~/Data/TE/elara_config.toml`

which is of limited use given that `elara run` already effectivelly does a dry run (so i'm not proposing to add documentation). But this PR also includes some minor changes to give better feedback.

I also completely removed the requirement for "name" in the config, eg:

```
[scenario]
name = "default"
```

This was already removed from almost all the output files names so was redundant.