### PR TITLE
pass github action s3 destination as environment secret

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -50,6 +50,8 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-1
     - name: Zip and Send to S3
+      env:
+        AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
       run: |
         echo $GITHUB_REPOSITORY
         repo_slug=`echo $GITHUB_REPOSITORY | awk -F '/' '{print $2}'`;
@@ -71,7 +73,7 @@ jobs:
         echo "Image version tag: $version_tag"
         echo $version_tag > image_tags
         zip -r app.zip .
-        aws s3 cp app.zip s3://arup-arup-ukimea-tcs-dev-test-code/$repo_slug.zip
+        aws s3 cp app.zip "s3://$AWS_S3_CODE_BUCKET/$repo_slug.zip"
     - name: Send build success notification
       if: success()
       uses: rtCamp/action-slack-notify@v2.0.0


### PR DESCRIPTION
This isn't a super security concern but better to elide it

Have added the value as a repository secret: 
![Screenshot 2022-06-07 at 15 31 19](https://user-images.githubusercontent.com/10106219/172406992-b6fad790-5c08-4fa8-9429-68efc99deb56.png)

**Update**
Confirmed S3 upload still works with this method of passing the S3 bucket name:
![Screenshot 2022-06-07 at 15 45 28](https://user-images.githubusercontent.com/10106219/172410123-72fcc3fd-7b65-4c7c-8a40-3911c9a18692.png)
