### PR TITLE
forces link ids to str

### DIFF
--- a/elara/benchmarking.py
+++ b/elara/benchmarking.py
@@ -627,6 +627,7 @@ class LinkCounterComparison(BenchmarkTool):
                 links = counter['links']
                 if links==[]:
                     continue # some links are empty lists, we skip them
+                links = [str(link) for link in links]  # force all ids to strings
                 bm_hours = [str(h) for h in list(counter['counts'])]
                 counts_array = np.array(list(counter['counts'].values()))
 
@@ -642,7 +643,7 @@ class LinkCounterComparison(BenchmarkTool):
 
                 # combine mode link counts
                 for link_id in links:
-                    if str(link_id) not in results_df.index:
+                    if link_id not in results_df.index:
                         failed_snaps += 1
                         self.logger.warning(
                             f" Missing model link: {link_id}, zero filling count for benchmark: "


### PR DESCRIPTION
minor change to fix tiny string bug encountered on run.

linkCounterComparison was 'temporarily' forcing links ids from integer to strings to make joins but later failing to write results with integer ids:

![image](https://user-images.githubusercontent.com/26383933/176878778-dfcdcb07-3732-495e-9e15-bfefc7d6cdd9.png)

This is now fixed by forcing all link ids to strings early on in the class.