### PR TITLE
adds more stringent dry run

### DIFF
--- a/elara/benchmarking.py
+++ b/elara/benchmarking.py
@@ -45,10 +45,28 @@ class CsvComparison(BenchmarkTool):
 
     output_value_fields = ['trips_benchmark', 'trip_simulation']
 
+    def dry_build(self, resources: dict, write_path: Optional[str] = None) -> dict:
+        """
+        Check format of benchmark data
+        """
+        super().build(resources, write_path)
+
+        self.logger.debug(f"Loading BM data from {self.benchmark_data_path}")
+        self.logger.debug(f"Using indices '{self.index_fields}'")
+        if not os.path.exists(self.benchmark_data_path):
+            raise UserWarning(f"Unable to find benchmark {self.benchmark_data_path}.")
+        benchmarks_df = pd.read_csv(self.benchmark_data_path, index_col=self.index_fields)
+        if self.value_field not in benchmarks_df.columns:
+            raise UserWarning(f"Incorrectly formatted benchmarks, expected {self.value_field} column.")
+
+        return {}
+
     def build(self, resources: dict, write_path: Optional[str] = None) -> dict:
         """
         Compare two csv files (benchmark vs simulation), calculate and plot their differences
         """
+        super().build(resources, write_path)
+
         # Read benchmark and simulation csv files
         self.logger.debug(f"Loading BM data from {self.benchmark_data_path}")
         self.logger.debug(f"Using indices '{self.index_fields}'")

--- a/elara/benchmarking.py
+++ b/elara/benchmarking.py
@@ -45,21 +45,25 @@ class CsvComparison(BenchmarkTool):
 
     output_value_fields = ['trips_benchmark', 'trip_simulation']
 
-    def dry_build(self, resources: dict, write_path: Optional[str] = None) -> dict:
+    def __init__(self, config, mode, groupby_person_attribute=None, **kwargs) -> None:
         """
-        Check format of benchmark data
+        Initiate class, checks benchmark data format.
+        :param config: Config object
+        :param mode: str, mode
+        :param attribute: str, atribute key defaults to None
         """
-        super().build(resources, write_path)
+        super().__init__(config=config, mode=mode, groupby_person_attribute=groupby_person_attribute, **kwargs)
 
         self.logger.debug(f"Loading BM data from {self.benchmark_data_path}")
         self.logger.debug(f"Using indices '{self.index_fields}'")
+        if self.benchmark_data_path is None:
+            return None  # todo this is required for the input plan comparison tools
         if not os.path.exists(self.benchmark_data_path):
             raise UserWarning(f"Unable to find benchmark {self.benchmark_data_path}.")
         benchmarks_df = pd.read_csv(self.benchmark_data_path, index_col=self.index_fields)
         if self.value_field not in benchmarks_df.columns:
             raise UserWarning(f"Incorrectly formatted benchmarks, expected {self.value_field} column.")
 
-        return {}
 
     def build(self, resources: dict, write_path: Optional[str] = None) -> dict:
         """
@@ -1362,7 +1366,7 @@ class InputPlanComparisonTripStart(PlanComparisonTripStart):
             'input_trip_logs_all_trips.csv'
         )
 
-        super().__init__(config)
+        super().__init__(config=config, mode="all")
 
         data_path_from_config = kwargs.get('benchmark_data_path', None)
         if data_path_from_config is not None:

--- a/elara/factory.py
+++ b/elara/factory.py
@@ -1,4 +1,3 @@
-from asyncore import write
 from typing import Dict, List, Union, Optional
 import pandas as pd
 import geopandas as gpd

--- a/elara/factory.py
+++ b/elara/factory.py
@@ -7,7 +7,10 @@ import os
 import json
 import logging
 from matplotlib.figure import Figure
-from fuzzywuzzy import process
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    from fuzzywuzzy import process
 
 from elara.helpers import camel_to_snake
 
@@ -519,7 +522,6 @@ class WorkStation:
 
         if self.resources:
             for tool_name, tool in self.resources.items():
-
                 tool.build(self.supplier_resources, write_path)
 
     def dry_build(self, write_path=None):
@@ -538,7 +540,6 @@ class WorkStation:
 
         if self.resources:
             for tool_name, tool in self.resources.items():
-
                 tool.dry_build(self.supplier_resources, write_path)
 
     def load_all_tools(self, mode=None, groupby_person_attribute=None) -> None:

--- a/elara/factory.py
+++ b/elara/factory.py
@@ -1,3 +1,4 @@
+from asyncore import write
 from typing import Dict, List, Union, Optional
 import pandas as pd
 import geopandas as gpd
@@ -117,6 +118,21 @@ class Tool:
         :return: None
         """
         self.logger.debug(f'Building Tool {self.__str__()}')
+        self.logger.debug(f'Resources handed to {self.__str__()} = {resource}')
+        self.resources = resource
+
+    def dry_build(
+            self,
+            resource: Dict[str, list],
+            write_path: Optional[str] = None
+    ) -> None:
+        """
+        Default build self.
+        :param resource: dict, supplier resources
+        :param write_path: Optional output path overwrite
+        :return: None
+        """
+        self.logger.debug(f'Dry Building Tool {self.__str__()}')
         self.logger.debug(f'Resources handed to {self.__str__()} = {resource}')
         self.resources = resource
 
@@ -506,6 +522,25 @@ class WorkStation:
 
                 tool.build(self.supplier_resources, write_path)
 
+    def dry_build(self, write_path=None):
+        """
+        Gather resources from suppliers for current workstation and build() all resources in
+        order of .resources map.
+        :param write_path: Optional output path overwrite
+        :return: None
+        """
+        self.logger.debug(f'Building Workstation {self.__str__()}')
+
+        # gather resources
+        if self.suppliers:
+            for supplier in self.suppliers:
+                self.supplier_resources.update(supplier.resources)
+
+        if self.resources:
+            for tool_name, tool in self.resources.items():
+
+                tool.dry_build(self.supplier_resources, write_path)
+
     def load_all_tools(self, mode=None, groupby_person_attribute=None) -> None:
         """
         Method used for testing.
@@ -735,9 +770,10 @@ def build(start_node: WorkStation, write_path=None) -> list:
     return build_dag(queue=queue, write_path=write_path)
 
 
-def dry_run_build(start_node: WorkStation) -> None:
+def dry_run_build(start_node: WorkStation, write_path=None) -> None:
     assemble_dag(start_node=start_node)
     queue = initiate_dag(start_node=start_node)
+    return dry_build_dag(queue=queue, write_path=write_path)
 
 
 def assemble_dag(start_node: WorkStation) -> None:
@@ -790,6 +826,21 @@ def build_dag(queue, write_path=None) -> list:
     while return_queue:
         current = return_queue.pop(0)
         current.build(write_path=write_path)
+        visited.append(current)
+
+    # return full sequence for testing
+    return queue + visited
+
+
+def dry_build_dag(queue, write_path=None) -> list:
+    # stage 3:
+    logger = logging.getLogger(__name__)
+    logger.info(f'Initiating Build')
+    return_queue = queue[::-1]
+    visited = []
+    while return_queue:
+        current = return_queue.pop(0)
+        current.dry_build(write_path=write_path)
         visited.append(current)
 
     # return full sequence for testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ pyproj==2.6.1.post1
 pytest-cov==3.0.0
 pytest==7.1.1
 pytest-xdist==2.5.0
+python-Levenshtein==0.12.2
 shapely==1.7.1
 toml==0.10.0
 tqdm==4.40.2
 fuzzywuzzy==0.18.0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ pyproj==2.6.1.post1
 pytest-cov==3.0.0
 pytest==7.1.1
 pytest-xdist==2.5.0
-python-Levenshtein==0.12.2
 shapely==1.7.1
 toml==0.10.0
 tqdm==4.40.2

--- a/scripts/elara_run_smoke_test.py
+++ b/scripts/elara_run_smoke_test.py
@@ -21,8 +21,8 @@ def parse_args(cmd_args):
 
 def print_banner():
     banner = '''
-            _____ _                 
-            | ____| | __ _ _ __ __ _ 
+            _____ _
+            | ____| | __ _ _ __ __ _
             |  _| | |/ _` | '__/ _` |
             | |___| | (_| | | | (_| |
             |_____|_|\__,_|_|  \__,_|
@@ -40,12 +40,12 @@ def print_banner():
    8):::::(8  ,ad8""
    Yb:;;;:d888""
     "8ggg8P"
-  ____                  _          _____         _   
- / ___| _ __ ___   ___ | | _____  |_   _|__  ___| |_ 
+  ____                  _          _____         _
+ / ___| _ __ ___   ___ | | _____  |_   _|__  ___| |_
  \___ \| '_ ` _ \ / _ \| |/ / _ \   | |/ _ \/ __| __|
-  ___) | | | | | | (_) |   <  __/   | |  __/\__ \ |_ 
+  ___) | | | | | | (_) |   <  __/   | |  __/\__ \ |_
  |____/|_| |_| |_|\___/|_|\_\___|   |_|\___||___/\__|
-                                 
+
     '''
     print("{}{}{}".format(Fore.CYAN, banner, Style.RESET_ALL))
 
@@ -72,6 +72,17 @@ def run_config(config_path, output_directory):
         'elara', 'run',
         '"{}"'.format(config_path),
         '--output_directory_override', '"{}"'.format(output_directory)
+        ]
+    return run_shell_command(execute_notebook_cmd)
+
+
+def dryrun_config(config_path, output_directory):
+    print("Executing config '{}{}{}'...".format(Fore.YELLOW, config_path, Style.RESET_ALL))
+    execute_notebook_cmd = [
+        'elara', 'run',
+        '"{}"'.format(config_path),
+        '--output_directory_override', '"{}"'.format(output_directory),
+        '-d'
         ]
     return run_shell_command(execute_notebook_cmd)
 
@@ -134,6 +145,8 @@ if __name__ == '__main__':
         run_results = {}
         for config in configs:
             print('------------------------------------------------------')
+            return_code, cmd, run_time = dryrun_config(config, output_directory)
+            run_results[f'{config}-dry-run'] = (return_code, run_time)
             return_code, cmd, run_time = run_config(config, output_directory)
             run_results[config] = (return_code, run_time)
 

--- a/tests/test_8_main.py
+++ b/tests/test_8_main.py
@@ -29,7 +29,8 @@ def test_config():
     return config
 
 
-def test_main(test_config):
+@pytest.fixture
+def test_requirements(test_config):
     requirements = RequirementsWorkStation(test_config)
     postprocessing = PostProcessWorkStation(test_config)
     benchmarks = BenchmarkWorkStation(test_config)
@@ -71,8 +72,25 @@ def test_main(test_config):
         managers=[input_workstation],
         suppliers=None
     )
+    return requirements
 
-    factory.build(requirements, write_path=test_outputs)
+
+def test_main(test_requirements):
+
+    factory.build(test_requirements, write_path=test_outputs)
+
+    path = os.path.join(test_outputs, 'stop_passenger_counts_bus_boardings.csv')
+    test_town_boardings_bus = pd.read_csv(path)
+    assert test_town_boardings_bus.loc[:, [str(h) for h in range(24)]].sum().sum() == 40000
+
+    path = os.path.join(benchmarks_path, 'benchmark_scores.csv')
+    benchmark_scores = pd.read_csv(path)
+    assert benchmark_scores.score.sum() == 0
+
+
+def test_drybuild_main(test_requirements):
+
+    factory.dry_run_build(test_requirements, write_path=test_outputs)
 
     path = os.path.join(test_outputs, 'stop_passenger_counts_bus_boardings.csv')
     test_town_boardings_bus = pd.read_csv(path)


### PR DESCRIPTION
adds a more careful init check to the csv comparison benchmark tool. More generally adds a "dry-run" build method to base factory.Tool and Workstation classes. This is then called during the (existing) dry run command, eg:

`elara run example_configs/benchmarks.toml -d`

Generally i am trying to give cheap and early guarantee that everything will work,

I am not including checking of input paths to these dry-runs. Because it is intended to be called in BitSim, prior to input paths being known. Behaviour is only tested very basically but also added to smoke tests. I have confirmed expected behaviour via some local experiments.

the python-levenstein warning is also now suppressed. This Closes Issue 211