### PR TITLE
fixes dry run for input plan comparisons

### DIFF
--- a/elara/benchmarking.py
+++ b/elara/benchmarking.py
@@ -54,6 +54,10 @@ class CsvComparison(BenchmarkTool):
         """
         super().__init__(config=config, mode=mode, groupby_person_attribute=groupby_person_attribute, **kwargs)
 
+        if self.unsafe_load:
+            self.logger.debug(f"Data path is {self.benchmark_data_path}")
+            return None
+
         self.logger.debug(f"Loading BM data from {self.benchmark_data_path}")
         self.logger.debug(f"Using indices '{self.index_fields}'")
         if self.benchmark_data_path is None:
@@ -1053,7 +1057,6 @@ class TransitInteractionComparison(BenchmarkTool):
                     'counter_id': counter_id,
                     'direction': direction,
                     'score': counter_score,
-
                 }
 
                 for i, time in enumerate(bm_hours):
@@ -1359,6 +1362,7 @@ class PlanComparisonTripStart(CsvComparison):
 
 class InputPlanComparisonTripStart(PlanComparisonTripStart):
     requirements = ['trip_logs', 'input_trip_logs']
+    unsafe_load = True
 
     def __init__(self, config, **kwargs) -> None:
         self.benchmark_data_path = os.path.join(
@@ -1387,6 +1391,7 @@ class PlanComparisonTripDuration(CsvComparison):
 
 class InputPlanComparisonTripDuration(PlanComparisonTripDuration):
     requirements = ['trip_logs', 'input_trip_logs']
+    unsafe_load = True
 
     def __init__(self, config, **kwargs) -> None:
 
@@ -1416,6 +1421,7 @@ class PlanComparisonActivityStart(CsvComparison):
 
 class InputPlanComparisonActivityStart(PlanComparisonActivityStart):
     requirements = ['trip_logs', 'input_trip_logs']
+    unsafe_load = True
 
     def __init__(self, config, **kwargs) -> None:
         self.benchmark_data_path = os.path.join(
@@ -1444,6 +1450,7 @@ class PlanComparisonActivityDuration(CsvComparison):
 
 class InputPlanComparisonActivityDuration(PlanComparisonActivityDuration):
     requirements = ['trip_logs', 'input_trip_logs']
+    unsafe_load = True
 
     def __init__(self, config, **kwargs) -> None:
         self.benchmark_data_path = os.path.join(
@@ -1463,6 +1470,7 @@ class InputPlanComparisonActivityDuration(PlanComparisonActivityDuration):
 class InputModeComparison(BenchmarkTool):
 
     requirements = ['input_trip_logs', 'trip_logs']
+    unsafe_load = True
     options_enabled = True
     weight = 1
     plot = True

--- a/elara/factory.py
+++ b/elara/factory.py
@@ -30,6 +30,7 @@ class Tool:
     """
     requirements = []
     options_enabled = False
+    unsafe_load = False
 
     mode = "all"
     groupby_person_attribute = None

--- a/example_configs/benchmarks.toml
+++ b/example_configs/benchmarks.toml
@@ -5,15 +5,17 @@ scale_factor = 0.0001
 crs = "EPSG:27700"
 verbose = false
 version = 12
-using_experienced_plans = false
+using_experienced_plans = true
 
 [inputs]
 events = "./tests/test_fixtures/output_events.xml"
 network = "./tests/test_fixtures/output_network.xml"
 transit_schedule = "./tests/test_fixtures/output_transitSchedule.xml"
 transit_vehicles = "./tests/test_fixtures/output_transitVehicles.xml"
-plans= "./tests/test_fixtures/output_plans.xml"
+plans = "./tests/test_fixtures/output_experienced_plans.xml"
+attributes = "./tests/test_fixtures/output_plans.xml"
 output_config_path = "./tests/test_fixtures/output_config.xml"
+input_plans = "./tests/test_fixtures/output_plans.xml"
 
 [outputs]
 path = "./outputs"
@@ -38,3 +40,8 @@ link_vehicle_speeds_comparison = {modes = ["car"], benchmark_data_path = "./exam
 link_vehicle_speeds_comparison--subpops = {modes = ["car"], benchmark_data_path = "./example_benchmark_data/test_fixtures/link_vehicle_speeds_car_average_subpopulation.csv", time_slice = 8, groupby_person_attributes=["subpopulation"]}
 trip_durations_comparison = {benchmark_data_path = "./example_benchmark_data/test_fixtures/trip_durations_car.csv"}
 trip_durations_comparison--mode_consistent = {benchmark_data_path = "./example_benchmark_data/test_fixtures/trip_durations_mode_consistency.csv", mode_consistent = true}
+input_plan_comparison_trip_duration = ["all"]
+input_plan_comparison_trip_start = ["all"]
+input_plan_comparison_activity_start = ["all"]
+input_plan_comparison_activity_duration = ["all"]
+input_mode_comparison = ["all"]


### PR DESCRIPTION
quick fix that keeps the dry run option working for the input plan comparisons.

These were causing issues because during the dry run (and more generally during init) the tools check for the existence benchmark paths.

For the input plan comparisons the benchmark data doesn't exist until during the run.

So i've added an `unsafe_load` param to all `factory.Tools` with default False. But for the input plan comparisons this is over-rided to True such that the paths are not checks, ie they are unchecked prior to the run ("unsafe" in elaras opinion). But in practice the user knows they should be fine because they will be built.

These input plan comparisons should be moved to their own module to make his clear in future.

Will merge this in a rush.