### PR TITLE
Pt interchange duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ tests/test_outputs/
 test_chunks.csv
 reports/
 tests_TC
+venv*

--- a/elara/plan_handlers.py
+++ b/elara/plan_handlers.py
@@ -539,7 +539,7 @@ class LegLogs(PlanHandlerTool):
 
                         act_type = stage.get('type')
 
-                        if not act_type == 'pt interaction':
+                        if not (act_type == 'pt interaction' and (stage.get('end_time') is None)):
 
                             trip_seq_idx += 1  # increment for a new trip idx
 

--- a/elara/plan_handlers.py
+++ b/elara/plan_handlers.py
@@ -802,6 +802,15 @@ class TripLogs(PlanHandlerTool):
 
                             activity_start_dt = activity_end_dt
 
+                        # if a 'pt interaction' activity has duration (ie it has an 'end_time' attribute)
+                        # then advance the next activity start time accordingly   
+                        elif stage.get('end_time'):
+                            end_time_str = stage.get('end_time')
+
+                            activity_start_dt = matsim_time_to_datetime(
+                                activity_start_dt, end_time_str, self.logger, idx=ident
+                            )
+
                     elif stage.tag == 'leg':
 
                         leg_mode = stage.get('mode')
@@ -999,7 +1008,7 @@ class PlanLogs(PlanHandlerTool):
                 if stage.tag == 'activity':
                     act_type = stage.get('type')
 
-                    if act_type == 'pt interaction':
+                    if not act_type == 'pt interaction':
 
                         end_time_str = stage.get('end_time', '23:59:59')
 
@@ -1049,6 +1058,16 @@ class PlanLogs(PlanHandlerTool):
                         in_transit = False
                         prev_x = x
                         prev_y = y
+                        arrival_dt = activity_end_dt
+
+                    # if a 'pt interaction' activity has duration (ie it has an 'end_time' attribute)
+                    # then advance the trip arrival time accordingly   
+                    elif stage.get('end_time'):
+                        end_time_str = stage.get('end_time')
+
+                        arrival_dt = matsim_time_to_datetime(
+                            arrival_dt, end_time_str, self.logger, idx=ident
+                        )
 
                 elif stage.tag == 'leg':
 
@@ -1063,7 +1082,7 @@ class PlanLogs(PlanHandlerTool):
                     trav_time = stage.get('trav_time')
                     h, m, s = trav_time.split(":")
                     td = timedelta(hours=int(h), minutes=int(m), seconds=int(s))
-                    arrival_dt = activity_end_dt + td
+                    arrival_dt = arrival_dt + td
 
             total_trips = len(trip_records)
             total_duration = sum([trip['act_duration'] for trip in trip_records])

--- a/elara/plan_handlers.py
+++ b/elara/plan_handlers.py
@@ -739,7 +739,6 @@ class TripLogs(PlanHandlerTool):
                     if stage.tag == 'activity':
                         act_type = stage.get('type')
 
-                        # if not act_type == 'pt interaction':
                         if not (act_type == 'pt interaction' and (stage.get('end_time') is None)):
 
                             act_seq_idx += 1  # increment for a new trip idx
@@ -1003,7 +1002,7 @@ class PlanLogs(PlanHandlerTool):
                 if stage.tag == 'activity':
                     act_type = stage.get('type')
 
-                    if not act_type == 'pt interaction':
+                    if not (act_type == 'pt interaction' and (stage.get('end_time') is None)):
 
                         end_time_str = stage.get('end_time', '23:59:59')
 

--- a/elara/plan_handlers.py
+++ b/elara/plan_handlers.py
@@ -739,7 +739,8 @@ class TripLogs(PlanHandlerTool):
                     if stage.tag == 'activity':
                         act_type = stage.get('type')
 
-                        if not act_type == 'pt interaction':
+                        # if not act_type == 'pt interaction':
+                        if not (act_type == 'pt interaction' and (stage.get('end_time') is None)):
 
                             act_seq_idx += 1  # increment for a new trip idx
                             trip_duration = activity_start_dt - activity_end_dt

--- a/elara/plan_handlers.py
+++ b/elara/plan_handlers.py
@@ -539,21 +539,18 @@ class LegLogs(PlanHandlerTool):
 
                         act_type = stage.get('type')
 
-                        if not (act_type == 'pt interaction' and (stage.get('end_time') is None)):
-
-                            trip_seq_idx += 1  # increment for a new trip idx
-
+                        if act_type != 'pt interaction' or stage.get('end_time'):
                             end_time_str = stage.get('end_time', '23:59:59')
-
                             activity_end_dt = matsim_time_to_datetime(
                                 arrival_dt, end_time_str, self.logger, idx=ident
                             )
-
-                            duration = activity_end_dt - arrival_dt
-
                         else:
-                            activity_end_dt = arrival_dt
-                            duration = arrival_dt - arrival_dt  # zero duration
+                            activity_end_dt = arrival_dt # zero duration for pt interactions without an end_time attribute
+
+                        if act_type != 'pt interaction':
+                            trip_seq_idx += 1  # increment for a new trip idx
+                        
+                        duration = activity_end_dt - arrival_dt  
 
                         x = stage.get('x')
                         y = stage.get('y')
@@ -739,7 +736,7 @@ class TripLogs(PlanHandlerTool):
                     if stage.tag == 'activity':
                         act_type = stage.get('type')
 
-                        if not (act_type == 'pt interaction' and (stage.get('end_time') is None)):
+                        if not act_type == 'pt interaction':
 
                             act_seq_idx += 1  # increment for a new trip idx
                             trip_duration = activity_start_dt - activity_end_dt
@@ -1002,7 +999,7 @@ class PlanLogs(PlanHandlerTool):
                 if stage.tag == 'activity':
                     act_type = stage.get('type')
 
-                    if not (act_type == 'pt interaction' and (stage.get('end_time') is None)):
+                    if act_type == 'pt interaction':
 
                         end_time_str = stage.get('end_time', '23:59:59')
 

--- a/tests/test_3_plan_handlers.py
+++ b/tests/test_3_plan_handlers.py
@@ -2610,18 +2610,18 @@ def test_non_zero_pt_interaction_legs(agent_leg_log_handler):
 		</plan>
 	</person>
     """
+
     person = etree.fromstring(person)
     handler.process_plans(person)
     assert handler.legs_log.chunk[-1]['start_s'] == 63000
-    
 
-def test_non_zero_pt_interaction_trips(agent_trip_handler):
-    """ PT interaction activity has non-zero duration , trip logs"""
+def test_zero_pt_interaction_legs(agent_leg_log_handler):
+    """ PT interaction activity has zero duration (not 'end_time' attribute in the 'pt interaction' activity ) """
 
-    handler = agent_trip_handler
+    handler = agent_leg_log_handler
 
     person = """
-	<person id="interaction_duration">
+	<person id="zero_interaction_duration">
 		<attributes>
 			<attribute name="subpopulation" class="java.lang.String">poor</attribute>
 			<attribute name="age" class="java.lang.String">no</attribute>
@@ -2635,7 +2635,7 @@ def test_non_zero_pt_interaction_trips(agent_trip_handler):
 				</attributes>
 				<route type="links" start_link="1-2" end_link="1-5" trav_time="00:00:04" distance="10100.0">1-2 2-1 1-5</route>
 			</leg>
-			<activity type="pt interaction" link="1-5" x="0.0" y="10000.0" end_time="17:30:00" >
+			<activity type="pt interaction" link="1-5" x="0.0" y="10000.0">
 			</activity>
 			<leg mode="walk" dep_time="17:30:00" trav_time="00:07:34">
 				<attributes>
@@ -2648,8 +2648,7 @@ def test_non_zero_pt_interaction_trips(agent_trip_handler):
 		</plan>
 	</person>
     """
+
     person = etree.fromstring(person)
     handler.process_plans(person)
-    print(handler.trips_log)
-    assert handler.trips_log.chunk[-1]['start_s'] == 63000
-    
+    assert handler.legs_log.chunk[-1]['start_s'] == 28804

--- a/tests/test_3_plan_handlers.py
+++ b/tests/test_3_plan_handlers.py
@@ -2576,3 +2576,42 @@ def test_load_workstation_with_logs(test_config, test_paths):
 
     assert os.path.exists(os.path.join(test_outputs, "trip_logs_all_trips.csv"))
     assert os.path.exists(os.path.join(test_outputs, "trip_logs_all_activities.csv"))
+
+def test_non_zero_pt_interaction(agent_leg_log_handler):
+    """ PT interaction activity has non-zero duration """
+
+    handler = agent_leg_log_handler
+
+    person = """
+	<person id="interaction_duration">
+		<attributes>
+			<attribute name="subpopulation" class="java.lang.String">poor</attribute>
+			<attribute name="age" class="java.lang.String">no</attribute>
+		</attributes>
+		<plan score="129.592238766919" selected="yes">
+			<activity type="home" link="1-2" x="0.0" y="0.0" end_time="08:00:00" >
+			</activity>
+			<leg mode="walk" dep_time="08:00:00" trav_time="00:00:04">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-2" end_link="1-5" trav_time="00:00:04" distance="10100.0">1-2 2-1 1-5</route>
+			</leg>
+			<activity type="pt interaction" link="1-5" x="0.0" y="10000.0" end_time="17:30:00" >
+			</activity>
+			<leg mode="walk" dep_time="17:30:00" trav_time="00:07:34">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-5" end_link="1-2" trav_time="00:07:34" distance="10100.0">1-5 5-1 1-2</route>
+			</leg>
+			<activity type="home" link="1-2" x="0.0" y="0.0" >
+			</activity>
+		</plan>
+	</person>
+    """
+    person = etree.fromstring(person)
+    handler.process_plans(person)
+    print(handler.results)
+    assert handler.legs_log.chunk[-1]['start_s'] == 63000
+    handler.finalise()

--- a/tests/test_3_plan_handlers.py
+++ b/tests/test_3_plan_handlers.py
@@ -2637,7 +2637,7 @@ def test_zero_pt_interaction_legs(agent_leg_log_handler):
 			</leg>
 			<activity type="pt interaction" link="1-5" x="0.0" y="10000.0">
 			</activity>
-			<leg mode="walk" dep_time="17:30:00" trav_time="00:07:34">
+			<leg mode="walk" dep_time="08:00:04" trav_time="00:07:34">
 				<attributes>
 					<attribute name="routingMode" class="java.lang.String">car</attribute>
 				</attributes>
@@ -2652,3 +2652,161 @@ def test_zero_pt_interaction_legs(agent_leg_log_handler):
     person = etree.fromstring(person)
     handler.process_plans(person)
     assert handler.legs_log.chunk[-1]['start_s'] == 28804
+
+
+def test_non_zero_pt_interaction_trips(agent_trip_handler):
+    """ PT interaction activity has non-zero duration """
+
+    handler = agent_trip_handler
+
+    person = """
+	<person id="interaction_duration">
+		<attributes>
+			<attribute name="subpopulation" class="java.lang.String">poor</attribute>
+			<attribute name="age" class="java.lang.String">no</attribute>
+		</attributes>
+		<plan score="129.592238766919" selected="yes">
+			<activity type="home" link="1-2" x="0.0" y="0.0" end_time="08:00:00" >
+			</activity>
+			<leg mode="walk" dep_time="08:00:00" trav_time="00:00:04">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-2" end_link="1-5" trav_time="00:00:04" distance="10100.0">1-2 2-1 1-5</route>
+			</leg>
+			<activity type="pt interaction" link="1-5" x="0.0" y="10000.0" end_time="17:30:00" >
+			</activity>
+			<leg mode="walk" dep_time="17:30:00" trav_time="00:07:34">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-5" end_link="1-2" trav_time="00:07:34" distance="10100.0">1-5 5-1 1-2</route>
+			</leg>
+			<activity type="home" link="1-2" x="0.0" y="0.0" >
+			</activity>
+		</plan>
+	</person>
+    """
+
+    person = etree.fromstring(person)
+    handler.process_plans(person)
+    assert handler.trips_log.chunk[-1]['end_s'] == 63454
+
+def test_zero_pt_interaction_trips(agent_trip_handler):
+    """ PT interaction activity has zero duration """
+
+    handler = agent_trip_handler
+
+    person = """
+	<person id="interaction_duration">
+		<attributes>
+			<attribute name="subpopulation" class="java.lang.String">poor</attribute>
+			<attribute name="age" class="java.lang.String">no</attribute>
+		</attributes>
+		<plan score="129.592238766919" selected="yes">
+			<activity type="home" link="1-2" x="0.0" y="0.0" end_time="08:00:00" >
+			</activity>
+			<leg mode="walk" dep_time="08:00:00" trav_time="00:00:04">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-2" end_link="1-5" trav_time="00:00:04" distance="10100.0">1-2 2-1 1-5</route>
+			</leg>
+			<activity type="pt interaction" link="1-5" x="0.0" y="10000.0">
+			</activity>
+			<leg mode="walk" dep_time="08:00:04" trav_time="00:07:34">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-5" end_link="1-2" trav_time="00:07:34" distance="10100.0">1-5 5-1 1-2</route>
+			</leg>
+			<activity type="home" link="1-2" x="0.0" y="0.0" >
+			</activity>
+		</plan>
+	</person>
+    """
+
+    person = etree.fromstring(person)
+    handler.process_plans(person)
+    assert handler.trips_log.chunk[-1]['end_s'] == 29258
+
+
+def test_non_zero_pt_interaction_plan(agent_plan_handler):
+    """ PT interaction activity has non-zero duration, plan logs """
+
+    handler = agent_plan_handler
+
+    person = """
+	<person id="nick">
+		<attributes>
+			<attribute name="subpopulation" class="java.lang.String">poor</attribute>
+			<attribute name="age" class="java.lang.String">no</attribute>
+		</attributes>
+		<plan score="129.592238766919" selected="yes">
+			<activity type="home" link="1-2" x="0.0" y="0.0" end_time="08:00:00" >
+			</activity>
+			<leg mode="walk" dep_time="08:00:00" trav_time="00:00:04">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-2" end_link="1-5" trav_time="00:00:04" distance="10100.0">1-2 2-1 1-5</route>
+			</leg>
+			<activity type="pt interaction" link="1-5" x="0.0" y="10000.0" end_time="17:30:00" >
+			</activity>
+			<leg mode="walk" dep_time="17:30:00" trav_time="00:07:34">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-5" end_link="1-2" trav_time="00:07:34" distance="10100.0">1-5 5-1 1-2</route>
+			</leg>
+			<activity type="home" link="1-2" x="0.0" y="0.0" >
+			</activity>
+		</plan>
+	</person>
+    """
+    
+    person = etree.fromstring(person)
+    handler.process_plans(person)
+    assert len(handler.plans_log.chunk) == 1
+    assert handler.plans_log.chunk[0]['act_duration'] == 22945
+    assert handler.plans_log.chunk[0]['start'] == 28800
+
+def test_zero_pt_interaction_plan(agent_plan_handler):
+    """ PT interaction activity has zero duration, plan logs """
+
+    handler = agent_plan_handler
+
+    person = """
+	<person id="nick">
+		<attributes>
+			<attribute name="subpopulation" class="java.lang.String">poor</attribute>
+			<attribute name="age" class="java.lang.String">no</attribute>
+		</attributes>
+		<plan score="129.592238766919" selected="yes">
+			<activity type="home" link="1-2" x="0.0" y="0.0" end_time="08:00:00" >
+			</activity>
+			<leg mode="walk" dep_time="08:00:00" trav_time="00:00:04">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-2" end_link="1-5" trav_time="00:00:04" distance="10100.0">1-2 2-1 1-5</route>
+			</leg>
+			<activity type="pt interaction" link="1-5" x="0.0" y="10000.0">
+			</activity>
+			<leg mode="walk" dep_time="08:00:04" trav_time="00:07:34">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-5" end_link="1-2" trav_time="00:07:34" distance="10100.0">1-5 5-1 1-2</route>
+			</leg>
+			<activity type="home" link="1-2" x="0.0" y="0.0" >
+			</activity>
+		</plan>
+	</person>
+    """
+    
+    person = etree.fromstring(person)
+    handler.process_plans(person)
+    assert len(handler.plans_log.chunk) == 1
+    assert handler.plans_log.chunk[0]['act_duration'] == 57141
+    assert handler.plans_log.chunk[0]['start'] == 28800

--- a/tests/test_3_plan_handlers.py
+++ b/tests/test_3_plan_handlers.py
@@ -2577,7 +2577,7 @@ def test_load_workstation_with_logs(test_config, test_paths):
     assert os.path.exists(os.path.join(test_outputs, "trip_logs_all_trips.csv"))
     assert os.path.exists(os.path.join(test_outputs, "trip_logs_all_activities.csv"))
 
-def test_non_zero_pt_interaction(agent_leg_log_handler):
+def test_non_zero_pt_interaction_legs(agent_leg_log_handler):
     """ PT interaction activity has non-zero duration """
 
     handler = agent_leg_log_handler
@@ -2612,6 +2612,44 @@ def test_non_zero_pt_interaction(agent_leg_log_handler):
     """
     person = etree.fromstring(person)
     handler.process_plans(person)
-    print(handler.results)
     assert handler.legs_log.chunk[-1]['start_s'] == 63000
-    handler.finalise()
+    
+
+def test_non_zero_pt_interaction_trips(agent_trip_handler):
+    """ PT interaction activity has non-zero duration , trip logs"""
+
+    handler = agent_trip_handler
+
+    person = """
+	<person id="interaction_duration">
+		<attributes>
+			<attribute name="subpopulation" class="java.lang.String">poor</attribute>
+			<attribute name="age" class="java.lang.String">no</attribute>
+		</attributes>
+		<plan score="129.592238766919" selected="yes">
+			<activity type="home" link="1-2" x="0.0" y="0.0" end_time="08:00:00" >
+			</activity>
+			<leg mode="walk" dep_time="08:00:00" trav_time="00:00:04">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-2" end_link="1-5" trav_time="00:00:04" distance="10100.0">1-2 2-1 1-5</route>
+			</leg>
+			<activity type="pt interaction" link="1-5" x="0.0" y="10000.0" end_time="17:30:00" >
+			</activity>
+			<leg mode="walk" dep_time="17:30:00" trav_time="00:07:34">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-5" end_link="1-2" trav_time="00:07:34" distance="10100.0">1-5 5-1 1-2</route>
+			</leg>
+			<activity type="home" link="1-2" x="0.0" y="0.0" >
+			</activity>
+		</plan>
+	</person>
+    """
+    person = etree.fromstring(person)
+    handler.process_plans(person)
+    print(handler.trips_log)
+    assert handler.trips_log.chunk[-1]['start_s'] == 63000
+    


### PR DESCRIPTION
In a recent simulation, we noticed that the "pt interaction" activity can have duration > 0. The plan handlers are ignoring those activities (see [here](https://github.com/arup-group/elara/blob/9ff050d6de4feac5ec804c0e6b1a02ba816b1851/elara/plan_handlers.py#L542)), and as a result the start times of the next leg end up wrong (since the [activity end time](https://github.com/arup-group/elara/blob/9ff050d6de4feac5ec804c0e6b1a02ba816b1851/elara/plan_handlers.py#L548) does not get updated.

We are not sure that this "pt interaction" activity represents in these cases.

I am trying to fix the timestamp bug by checking for an "end_time" tag in the "pt interaction" activity. If there is one, then pt interaction is treated as a normal activity, separating legs/trips either side. 
