### PR TITLE
remove the plotnine dependency and update related function

### DIFF
--- a/elara/benchmarking.py
+++ b/elara/benchmarking.py
@@ -2268,5 +2268,7 @@ def comparative_plots(results):
     ax.set_xlabel("Time (hour)")
     ax.set_ylabel("Volume")
     ax.legend(loc='best')
+    ax.grid(linestyle = '--', linewidth = 0.5)
+    ax.set_axisbelow(True) 
 
     return fig

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ networkx==2.4
 numpy==1.19.0
 matplotlib==3.5
 pandas==1.3.5
-plotnine==0.7.1
 polyline==1.4.0
 pyarrow==7.0.0
 pyproj==2.6.1.post1


### PR DESCRIPTION
Since the plotnine dependency produced multiple dependency conflicts([issue #225](https://github.com/arup-group/elara/issues/225)), and the conflict/bug is not straightforward to capture. I have changed the related plotnine functions using matplotlib instead and remove the dependency. 

I think the changes affect some comparison plots like link counter comparison. The new comparison plot look like more consistent with other comparison plots since they all use matplotlib. Not sure why it used ggplot from plotnine previously but we can add plot style as 'ggplot' if we would like to. 

New plot via matplotlib: 
![link_counter_comparison_car_B_summary_normalised](https://user-images.githubusercontent.com/58612648/204857513-16a08c6a-77ec-434a-8c1e-a659226a2f47.png)

old ggplot via plotnine:
![link_counter_comparison_car_B_summary_normalised_old](https://user-images.githubusercontent.com/58612648/204858013-06d633be-9cce-4bb1-987e-64766b588703.png)

There is a quite old mode share comparison function `OldModeSharesComparison` based on another plot functions via plot nine. I think we are using `TripModeSharesComparison ` to show the mode share differences instead of the old function so I just remove it. 