### PR TITLE
Add missing vehicle to passenger log requirements

### DIFF
--- a/elara/event_handlers.py
+++ b/elara/event_handlers.py
@@ -2118,7 +2118,7 @@ class VehiclePassengerLog(EventHandlerTool):
     Extract a log of passenger boardings and alightings to a PT vehicle.
     """
 
-    requirements = ['events', 'transit_schedule']
+    requirements = ['events', 'transit_schedule', 'vehicles']
 
     def __init__(self, config, mode="all", **kwargs):
         super().__init__(config, mode, **kwargs)


### PR DESCRIPTION
Fix missing vehicles error for `passenger_log` in the event handler when Elara fails to output the passenger log. Original PR #229
 
![Screenshot 2023-05-17 at 12 17 09](https://github.com/arup-group/elara/assets/58612648/23b74a06-1418-42b7-acaf-133027ef0ae6)
