### PR TITLE
Fix codebuild build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM python:3.8-slim
+FROM python:3.8-slim-bullseye
 
 RUN apt-get update \
 && apt-get upgrade -y \
-&& apt-get -y install gnupg \
-&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9 F8D2585B8783D481 6ED0E7B82643E131 BDE6D2B9216EC7A8 648ACFD622F3D138 54404762BBB6E853 \
 && apt-get -y install libspatialindex-dev --no-install-recommends \
 && rm -rf /var/lib/apt/lists/* \
 && /usr/local/bin/python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.8-slim
 
 RUN apt-get update \
 && apt-get upgrade -y \
-&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9 F8D2585B8783D481 6ED0E7B82643E131 BDE6D2B9216EC7A8 648ACFD622F3D138 54404762BBB6E853
+&& apt-get -y install gnupg \
+&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9 F8D2585B8783D481 6ED0E7B82643E131 BDE6D2B9216EC7A8 648ACFD622F3D138 54404762BBB6E853 \
 && apt-get -y install libspatialindex-dev --no-install-recommends \
 && rm -rf /var/lib/apt/lists/* \
 && /usr/local/bin/python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.8-slim
 
 RUN apt-get update \
 && apt-get upgrade -y \
+&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9 F8D2585B8783D481 6ED0E7B82643E131 BDE6D2B9216EC7A8 648ACFD622F3D138 54404762BBB6E853
 && apt-get -y install libspatialindex-dev --no-install-recommends \
 && rm -rf /var/lib/apt/lists/* \
 && /usr/local/bin/python -m pip install --upgrade pip


### PR DESCRIPTION
## The Problem

Although the Docker image builds locally, it has been failing consistently in CodeBuild for over a week in a way that I have been unable to reproduce outside of CodeBuild. The errors looked exactly like the ones described [here](https://discuss.circleci.com/t/apt-get-update-no-pubkey/48378/7), even though that is a CircleCI build rather than CodeBuild.

## The Solution

Also as described [here](https://discuss.circleci.com/t/apt-get-update-no-pubkey/48378/7), the solution was to switch to a different base image from the same provider.

## Validation of the Solution

- Successfully built the Docker image locally
- The CI/CD pipeline kicked in on the branch and ultimately led to our first successful CodeBuild build & push to ECR in a week or so: <img width="1273" alt="Screenshot 2023-06-28 at 02 22 23" src="https://github.com/arup-group/elara/assets/250899/c17607b5-5dfb-4a20-a99d-7eb0aaa2992c">
- The CodeBuild job spec includes a basic smoke test of the Docker image that involves launching a container from the image and then running the Elara unit tests inside the container, as a way to validate that the dependencies are all present and correct
- The compressed size of the Docker image in ECR is very marginally bigger than it was with the previous base image: <img width="777" alt="Screenshot 2023-06-28 at 02 33 55" src="https://github.com/arup-group/elara/assets/250899/e74e10a1-bbb4-46a7-a3af-c6713a752443">
- I haven't run any Elara commands in a container launched from the new image; what would be some good commands I could use to verify that Elara runs properly in the container?

