### PR TITLE
bugfix 236

### DIFF
--- a/elara/event_handlers.py
+++ b/elara/event_handlers.py
@@ -56,7 +56,7 @@ class EventHandlerTool(Tool):
         :param vehicle_id: Vehicle ID string
         :return: Vehicle mode type string
         """
-        if vehicle_id in self.resources['transit_schedule'].veh_to_mode_map.keys():
+        if self.resources['transit_schedule'].is_transit(vehicle_id=vehicle_id):
             return self.resources['transit_schedule'].veh_to_mode_map[vehicle_id]
         elif vehicle_id in self.resources['vehicles'].veh_to_mode_map:
             return self.resources['vehicles'].veh_to_mode_map[vehicle_id]

--- a/elara/inputs.py
+++ b/elara/inputs.py
@@ -321,6 +321,15 @@ class TransitSchedule(InputTool):
 
         self.logger.debug(f'Transit Schedule Route modes = {self.modes}')
         self.logger.debug(f'Transit Schedule Stop modes = {list(self.mode_to_stops_map)}')
+    
+    
+    def is_transit(self, vehicle_id: str) -> bool:
+        """Given a vehicle's ID, return if it is a transit mode.
+        Based on existance in veh_to_mode_map.
+        :param vehicle_id: Vehicle ID string
+        :return: bool
+        """
+        return vehicle_id in self.veh_to_mode_map
 
     @staticmethod
     def get_node_elem(elem):

--- a/tests/test_3_plan_handlers.py
+++ b/tests/test_3_plan_handlers.py
@@ -838,6 +838,35 @@ def test_finalised_plans(agent_plans_handler_finalised):
     assert len(handler.results) == 0
 
 
+def test_unselected_pt_plans(test_config, input_manager):
+    handler = plan_handlers.PlanLogs(test_config, "all")
+    resources = input_manager.resources
+    handler.build(resources, write_path=test_outputs)
+
+    plans = handler.resources["plans"]
+    for plan in plans.persons:
+        handler.process_plans(plan)
+
+    string = """
+    <person id="nick">
+        <plan score="100" selected="no">
+            <activity type="home" link="1-2" x="0.0" y="0.0" end_time="08:00:00" >
+            </activity>
+            <leg mode="bus" dep_time="08:00:00" trav_time="00:00:04">
+            <route type="links" start_link="1-2" end_link="1-5" trav_time="00:00:04" distance="10100.0">1-2 2-1 1-5</route>
+            </leg>
+            <activity type="work" link="1-5" x="0.0" y="10000.0" end_time="17:30:00" >
+            </activity>
+        </plan>
+    </person>
+    """
+    person = etree.fromstring(string)
+    handler.process_plans(person)
+
+    assert handler.trips_log.chunk[-1]["selected"]=="no"
+    assert handler.trips_log.chunk[-1]["mode"]=="bus"
+
+
 # Plans Wrapping case
 
 

--- a/tests/test_3_plan_handlers.py
+++ b/tests/test_3_plan_handlers.py
@@ -12,7 +12,7 @@ import lxml.etree as etree
 from datetime import datetime, timedelta
 
 
-sys.path.append(os.path.abspath('../elara'))
+sys.path.append(os.path.abspath("../elara"))
 
 test_dir = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 test_inputs = os.path.join(test_dir, "test_intermediate_data")
@@ -25,8 +25,8 @@ if not os.path.exists(benchmarks_path):
 
 
 test_matsim_time_data = [
-    ('00:00:00', 0),
-    ('01:01:01', 3661),
+    ("00:00:00", 0),
+    ("01:01:01", 3661),
     (None, None),
 ]
 
@@ -39,7 +39,7 @@ def test_convert_time(time, seconds):
 # Config
 @pytest.fixture
 def test_config():
-    config_path = os.path.join(test_dir, 'test_xml_scenario.toml')
+    config_path = os.path.join(test_dir, "test_xml_scenario.toml")
     config = Config(config_path)
     assert config
     return config
@@ -47,7 +47,7 @@ def test_config():
 
 @pytest.fixture
 def test_config_v12():
-    config_path = os.path.join(test_dir, 'test_xml_scenario_v12.toml')
+    config_path = os.path.join(test_dir, "test_xml_scenario_v12.toml")
     config = Config(config_path)
     assert config
     return config
@@ -55,7 +55,7 @@ def test_config_v12():
 
 @pytest.fixture
 def test_config_v13():
-    config_path = os.path.join(test_dir, 'test_xml_scenario_v13.toml')
+    config_path = os.path.join(test_dir, "test_xml_scenario_v13.toml")
     config = Config(config_path)
     assert config
     return config
@@ -108,26 +108,26 @@ def input_manager_v12(test_config_v12, test_paths_v12):
 # Base
 @pytest.fixture
 def base_handler(test_config, input_manager):
-    base_handler = plan_handlers.PlanHandlerTool(test_config, 'all')
-    assert base_handler.mode == 'all'
+    base_handler = plan_handlers.PlanHandlerTool(test_config, "all")
+    assert base_handler.mode == "all"
     base_handler.build(input_manager.resources, write_path=test_outputs)
     return base_handler
 
 
 @pytest.fixture
 def base_handler_v12(test_config_v12, input_manager):
-    base_handler = plan_handlers.PlanHandlerTool(test_config_v12, 'all')
-    assert base_handler.mode == 'all'
+    base_handler = plan_handlers.PlanHandlerTool(test_config_v12, "all")
+    assert base_handler.mode == "all"
     base_handler.build(input_manager.resources, write_path=test_outputs)
     return base_handler
 
 
 mode_distances = [
-    ({'a': 2, 'b': 0.5}, 'a'),
-    ({'a': 2, 'b': 2}, 'a'),
-    ({'a': 2}, 'a'),
-    ({'a': 2, 'b': -1}, 'a'),
-    ({'transit_walk': 2, 'b': 1}, 'b'),
+    ({"a": 2, "b": 0.5}, "a"),
+    ({"a": 2, "b": 2}, "a"),
+    ({"a": 2}, "a"),
+    ({"a": 2, "b": -1}, "a"),
+    ({"transit_walk": 2, "b": 1}, "b"),
     ({None: 1}, None),
 ]
 
@@ -140,7 +140,8 @@ def get_furthest_mode(modes, mode):
 def test_extract_mode_from_v11_route_elem(base_handler):
     class Resource:
         route_to_mode_map = {"a": "bus"}
-    base_handler.resources['transit_schedule'] = Resource()
+
+    base_handler.resources["transit_schedule"] = Resource()
     string = """
     <route type="experimentalPt1" start_link="1-2" end_link="3-4" trav_time="00:43:42"
     distance="10100.0">PT1===home_stop_out===city_line===a===work_stop_in</route>
@@ -152,7 +153,8 @@ def test_extract_mode_from_v11_route_elem(base_handler):
 def test_extract_routeid_from_v12_route_elem(base_handler):
     class Resource:
         route_to_mode_map = {"a": "bus"}
-    base_handler.resources['transit_schedule'] = Resource()
+
+    base_handler.resources["transit_schedule"] = Resource()
     string = """
     <route type="default_pt" start_link="1"
     end_link="2" trav_time="00:33:03" distance="2772.854305426653">
@@ -166,7 +168,8 @@ def test_extract_routeid_from_v12_route_elem(base_handler):
 def test_extract_mode_from_route_elem_v11(base_handler):
     class Resource:
         route_to_mode_map = {"a": "bus"}
-    base_handler.resources['transit_schedule'] = Resource()
+
+    base_handler.resources["transit_schedule"] = Resource()
     string = """
     <route type="experimentalPt1" start_link="1-2" end_link="3-4" trav_time="00:43:42"
     distance="10100.0">PT1===home_stop_out===city_line===a===work_stop_in</route>
@@ -178,7 +181,8 @@ def test_extract_mode_from_route_elem_v11(base_handler):
 def test_extract_mode_from_route_elem_v12(base_handler_v12):
     class Resource:
         route_to_mode_map = {"a": "bus"}
-    base_handler_v12.resources['transit_schedule'] = Resource()
+
+    base_handler_v12.resources["transit_schedule"] = Resource()
     string = """
     <route type="default_pt" start_link="1"
     end_link="2" trav_time="00:33:03" distance="2772.854305426653">
@@ -190,6 +194,7 @@ def test_extract_mode_from_route_elem_v12(base_handler_v12):
 
 
 ### Utility Handler ###
+
 
 @pytest.fixture
 def person_single_plan_elem():
@@ -217,7 +222,7 @@ def person_plans_elem():
 
 @pytest.fixture
 def utility_handler(test_config, input_manager):
-    handler = plan_handlers.UtilityLogs(test_config, 'all')
+    handler = plan_handlers.UtilityLogs(test_config, "all")
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
     assert len(handler.utility_log.chunk) == 0
@@ -228,48 +233,50 @@ def test_utility_handler_process_single_plan(utility_handler, person_single_plan
     assert len(utility_handler.utility_log) == 0
     utility_handler.process_plans(person_single_plan_elem)
     assert len(utility_handler.utility_log) == 1
-    assert utility_handler.utility_log.chunk == [
-        {'agent': 'test1', 'score': '10'}]
+    assert utility_handler.utility_log.chunk == [{"agent": "test1", "score": "10"}]
 
 
 def test_utility_handler_process_multi_plan(utility_handler, person_plans_elem):
     assert len(utility_handler.utility_log) == 0
     utility_handler.process_plans(person_plans_elem)
     assert len(utility_handler.utility_log) == 1
-    assert utility_handler.utility_log.chunk == [
-        {'agent': 'test2', 'score': '10'}]
+    assert utility_handler.utility_log.chunk == [{"agent": "test2", "score": "10"}]
 
 
-def test_utility_handler_process_plans(utility_handler, person_single_plan_elem, person_plans_elem):
+def test_utility_handler_process_plans(
+    utility_handler, person_single_plan_elem, person_plans_elem
+):
     assert len(utility_handler.utility_log) == 0
     utility_handler.process_plans(person_single_plan_elem)
     utility_handler.process_plans(person_plans_elem)
     assert len(utility_handler.utility_log) == 2
     assert utility_handler.utility_log.chunk == [
-        {'agent': 'test1', 'score': '10'}, {'agent': 'test2', 'score': '10'}]
+        {"agent": "test1", "score": "10"},
+        {"agent": "test2", "score": "10"},
+    ]
 
 
 ### Leg Log Handler ###
 # Wrapping
 test_matsim_time_data = [
-    (['06:00:00', '12:45:00', '18:30:00'], '1-18:30:00'),
-    (['06:00:00', '12:45:00', '24:00:00'], '2-00:00:00'),
-    (['06:00:00', '24:00:00', '08:30:00'], '2-08:30:00'),
-    (['06:00:00', '18:45:00', '12:30:00'], '2-12:30:00'),
-    (['06:00:00', '18:45:00', '18:45:00'], '1-18:45:00'),
-    (['00:00:00', '12:45:00', '18:45:00'], '1-18:45:00'),
-    (['06:00:00', '04:45:00', '02:45:00'], '3-02:45:00'),
-    (['00:00:00'], '1-00:00:00'),
-    (['24:00:00'], '2-00:00:00'),
+    (["06:00:00", "12:45:00", "18:30:00"], "1-18:30:00"),
+    (["06:00:00", "12:45:00", "24:00:00"], "2-00:00:00"),
+    (["06:00:00", "24:00:00", "08:30:00"], "2-08:30:00"),
+    (["06:00:00", "18:45:00", "12:30:00"], "2-12:30:00"),
+    (["06:00:00", "18:45:00", "18:45:00"], "1-18:45:00"),
+    (["00:00:00", "12:45:00", "18:45:00"], "1-18:45:00"),
+    (["06:00:00", "04:45:00", "02:45:00"], "3-02:45:00"),
+    (["00:00:00"], "1-00:00:00"),
+    (["24:00:00"], "2-00:00:00"),
 ]
 
 non_wrapping_test_matsim_time_data = [
-    (['06:00:00', '12:45:00', '18:30:00'], '1-18:30:00'),
-    (['06:00:00', '12:45:00', '24:00:00'], '2-00:00:00'),
-    (['06:00:00', '24:00:00', '08:30:00'], '1-08:30:00'),
-    (['06:00:00', '18:45:00', '12:30:00'], '1-12:30:00'),
-    (['00:00:00'], '1-00:00:00'),
-    (['24:00:00'], '2-00:00:00'),
+    (["06:00:00", "12:45:00", "18:30:00"], "1-18:30:00"),
+    (["06:00:00", "12:45:00", "24:00:00"], "2-00:00:00"),
+    (["06:00:00", "24:00:00", "08:30:00"], "1-08:30:00"),
+    (["06:00:00", "18:45:00", "12:30:00"], "1-12:30:00"),
+    (["00:00:00"], "1-00:00:00"),
+    (["24:00:00"], "2-00:00:00"),
 ]
 
 
@@ -284,32 +291,39 @@ def test_matsim_time_to_datetime(times, final_string):
             base_month=1,
         )
     assert isinstance(current_dt, datetime)
-    assert current_dt == datetime.strptime(f"{final_string}", '%d-%H:%M:%S')
+    assert current_dt == datetime.strptime(f"{final_string}", "%d-%H:%M:%S")
 
 
 test_durations_data = [
     (
-        None, datetime(year=2020, month=4, day=1, hour=0),
-        timedelta(hours=0), datetime(year=2020, month=4, day=1, hour=0)
+        None,
+        datetime(year=2020, month=4, day=1, hour=0),
+        timedelta(hours=0),
+        datetime(year=2020, month=4, day=1, hour=0),
     ),
     (
-        None, datetime(year=2020, month=4, day=1, hour=1),
-        timedelta(hours=1), datetime(year=2020, month=4, day=1, hour=0)
+        None,
+        datetime(year=2020, month=4, day=1, hour=1),
+        timedelta(hours=1),
+        datetime(year=2020, month=4, day=1, hour=0),
     ),
     (
-        datetime(year=2020, month=4, day=1, hour=1), datetime(
-            year=2020, month=4, day=1, hour=1),
-        timedelta(hours=0), datetime(year=2020, month=4, day=1, hour=1)
+        datetime(year=2020, month=4, day=1, hour=1),
+        datetime(year=2020, month=4, day=1, hour=1),
+        timedelta(hours=0),
+        datetime(year=2020, month=4, day=1, hour=1),
     ),
     (
-        datetime(year=2020, month=4, day=1, hour=1), datetime(
-            year=2020, month=4, day=1, hour=2),
-        timedelta(hours=1), datetime(year=2020, month=4, day=1, hour=1)
+        datetime(year=2020, month=4, day=1, hour=1),
+        datetime(year=2020, month=4, day=1, hour=2),
+        timedelta(hours=1),
+        datetime(year=2020, month=4, day=1, hour=1),
     ),
     (
-        datetime(year=2020, month=4, day=1, hour=2), datetime(
-            year=2020, month=4, day=1, hour=1),
-        timedelta(hours=-1), datetime(year=2020, month=4, day=1, hour=2)
+        datetime(year=2020, month=4, day=1, hour=2),
+        datetime(year=2020, month=4, day=1, hour=1),
+        timedelta(hours=-1),
+        datetime(year=2020, month=4, day=1, hour=2),
     ),
 ]
 
@@ -326,7 +340,7 @@ test_distance_data = [
     (1, 1, 1, 1, 0),
     (0, 0, 3, 4, 5),
     (3, 4, 0, 0, 5),
-    (3, 0, 0, -4, 5)
+    (3, 0, 0, -4, 5),
 ]
 
 
@@ -338,7 +352,7 @@ def test_distance(x1, y1, x2, y2, dist):
 # Normal Case
 @pytest.fixture
 def agent_leg_log_handler(test_config, input_manager):
-    handler = plan_handlers.LegLogs(test_config, 'all')
+    handler = plan_handlers.LegLogs(test_config, "all")
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -352,7 +366,7 @@ def agent_leg_log_handler(test_config, input_manager):
 def test_agent_log_handler(agent_leg_log_handler):
     handler = agent_leg_log_handler
 
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for person in plans.persons:
         handler.process_plans(person)
 
@@ -363,7 +377,7 @@ def test_agent_log_handler(agent_leg_log_handler):
 @pytest.fixture
 def agent_leg_log_handler_finalised(agent_leg_log_handler):
     handler = agent_leg_log_handler
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for plan in plans.persons:
         handler.process_plans(plan)
     handler.finalise()
@@ -378,10 +392,11 @@ def test_finalised_logs(agent_leg_log_handler_finalised):
 
 # Plans Wrapping case
 
+
 # Bad Config (plans wrap past 24hrs)
 @pytest.fixture
 def test_bad_plans_config():
-    config_path = os.path.join(test_dir, 'test_xml_scenario_bad_plans.toml')
+    config_path = os.path.join(test_dir, "test_xml_scenario_bad_plans.toml")
     config = Config(config_path)
     assert config
     return config
@@ -410,7 +425,7 @@ def input_bad_plans_manager(test_bad_plans_config, test_bad_plans_paths):
 
 @pytest.fixture
 def agent_leg_log_handler_bad_plans(test_bad_plans_config, input_bad_plans_manager):
-    handler = plan_handlers.LegLogs(test_bad_plans_config, 'all')
+    handler = plan_handlers.LegLogs(test_bad_plans_config, "all")
 
     resources = input_bad_plans_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -424,11 +439,11 @@ def agent_leg_log_handler_bad_plans(test_bad_plans_config, input_bad_plans_manag
 @pytest.fixture
 def agent_leg_log_handler_finalised_bad_plans(agent_leg_log_handler_bad_plans):
     handler = agent_leg_log_handler_bad_plans
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for plan in plans.persons:
         handler.process_plans(plan)
-    assert handler.activities_log.chunk[-1].get('end_day') == 1
-    assert handler.legs_log.chunk[-1].get('end_day') == 1
+    assert handler.activities_log.chunk[-1].get("end_day") == 1
+    assert handler.legs_log.chunk[-1].get("end_day") == 1
     handler.finalise()
     return handler
 
@@ -437,17 +452,19 @@ def test_finalised_logs_bad_plans(agent_leg_log_handler_finalised_bad_plans):
     handler = agent_leg_log_handler_finalised_bad_plans
     assert len(handler.results) == 0
 
+
 ### Toll Log Handler ###
 
 
 @pytest.fixture
 def toll_log_handler(test_config, input_manager):
-    handler = plan_handlers.AgentTollsPaidFromRPConfig(test_config, 'car')
+    handler = plan_handlers.AgentTollsPaidFromRPConfig(test_config, "car")
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
 
     return handler
+
 
 # paying single toll
 
@@ -471,7 +488,8 @@ def test_toll_onelink(toll_log_handler):
     person = etree.fromstring(person)
     handler.process_plans(person)
     assert len(handler.toll_log) == 1
-    assert handler.toll_log.iloc[0]['toll'] == '10.0'
+    assert handler.toll_log.iloc[0]["toll"] == "10.0"
+
 
 # using two adjacent toll links consecutively should only incur one charge
 
@@ -495,7 +513,8 @@ def test_toll_consecutivelinks(toll_log_handler):
     person = etree.fromstring(person)
     handler.process_plans(person)
     assert len(handler.toll_log) == 1
-    assert handler.toll_log.iloc[0]['toll'] == '10.0'
+    assert handler.toll_log.iloc[0]["toll"] == "10.0"
+
 
 # using two adjacent toll links non-consecutively should incur charge twice
 
@@ -519,8 +538,11 @@ def test_toll_nonconsecutivelinks(toll_log_handler):
     person = etree.fromstring(person)
     handler.process_plans(person)
     assert len(handler.toll_log) == 2
-    assert float(handler.toll_log.iloc[0]['toll']) + \
-        float(handler.toll_log.iloc[1]['toll']) == 20
+    assert (
+        float(handler.toll_log.iloc[0]["toll"])
+        + float(handler.toll_log.iloc[1]["toll"])
+        == 20
+    )
 
 
 def test_toll_finalise(toll_log_handler):
@@ -542,26 +564,27 @@ def test_toll_finalise(toll_log_handler):
     person = etree.fromstring(person)
     handler.process_plans(person)
     handler.finalise()
-    assert handler.results['tolls_paid_total_by_agent'].sum() == 20
+    assert handler.results["tolls_paid_total_by_agent"].sum() == 20
 
 
 def test_toll_tagged(toll_log_handler):
     handler = toll_log_handler
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for plan in plans.persons:
         handler.process_plans(plan)
     handler.finalise()
-    assert handler.results['tolls_paid_log'].iloc[1]['tollname'] == "Toll Road 3"
-    assert handler.results['tolls_paid_log'].iloc[3]['tollname'] == "missing"
+    assert handler.results["tolls_paid_log"].iloc[1]["tollname"] == "Toll Road 3"
+    assert handler.results["tolls_paid_log"].iloc[3]["tollname"] == "missing"
     return handler
 
 
 ### Trip Log Handler ###
 
+
 # Normal Case
 @pytest.fixture
 def agent_trip_handler(test_config, input_manager):
-    handler = plan_handlers.TripLogs(test_config, 'all')
+    handler = plan_handlers.TripLogs(test_config, "all")
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -593,25 +616,26 @@ def test_agent_trip_log_process_person(agent_trip_handler):
     handler.process_plans(person)
 
     assert handler.activities_log.chunk[0]["start_s"] == 0
-    assert handler.activities_log.chunk[0]["duration_s"] == 8*60*60
-    assert handler.activities_log.chunk[0]["end_s"] == 8*60*60
+    assert handler.activities_log.chunk[0]["duration_s"] == 8 * 60 * 60
+    assert handler.activities_log.chunk[0]["end_s"] == 8 * 60 * 60
     assert handler.activities_log.chunk[0]["act"] == "home"
 
-    assert handler.trips_log.chunk[0]["start_s"] == 8*60*60
+    assert handler.trips_log.chunk[0]["start_s"] == 8 * 60 * 60
     assert handler.trips_log.chunk[0]["duration_s"] == 4
-    assert handler.trips_log.chunk[0]["end_s"] == 8*60*60 + 4
+    assert handler.trips_log.chunk[0]["end_s"] == 8 * 60 * 60 + 4
     assert handler.trips_log.chunk[0]["mode"] == "car"
 
-    assert handler.activities_log.chunk[1]["start_s"] == 8*60*60 + 4
-    assert handler.activities_log.chunk[1]["duration_s"] == 17.5 * \
-        60*60 - (8*60*60 + 4)
-    assert handler.activities_log.chunk[1]["end_s"] == 17.5*60*60
+    assert handler.activities_log.chunk[1]["start_s"] == 8 * 60 * 60 + 4
+    assert handler.activities_log.chunk[1]["duration_s"] == 17.5 * 60 * 60 - (
+        8 * 60 * 60 + 4
+    )
+    assert handler.activities_log.chunk[1]["end_s"] == 17.5 * 60 * 60
     assert handler.activities_log.chunk[1]["act"] == "work"
 
 
 def test_agent_trip_log_process_pt_bus_person(agent_trip_handler):
     handler = agent_trip_handler
-    handler.resources['transit_schedule'].route_to_mode_map["rail_dummy"] = "rail"
+    handler.resources["transit_schedule"].route_to_mode_map["rail_dummy"] = "rail"
 
     person = """
     <person id="nick">
@@ -645,25 +669,26 @@ def test_agent_trip_log_process_pt_bus_person(agent_trip_handler):
     handler.process_plans(person)
 
     assert handler.activities_log.chunk[0]["start_s"] == 0
-    assert handler.activities_log.chunk[0]["duration_s"] == 8*60*60
-    assert handler.activities_log.chunk[0]["end_s"] == 8*60*60
+    assert handler.activities_log.chunk[0]["duration_s"] == 8 * 60 * 60
+    assert handler.activities_log.chunk[0]["end_s"] == 8 * 60 * 60
     assert handler.activities_log.chunk[0]["act"] == "home"
 
-    assert handler.trips_log.chunk[0]["start_s"] == 8*60*60
-    assert handler.trips_log.chunk[0]["duration_s"] == 1.5*60*60
-    assert handler.trips_log.chunk[0]["end_s"] == 8*60*60 + 1.5*60*60
+    assert handler.trips_log.chunk[0]["start_s"] == 8 * 60 * 60
+    assert handler.trips_log.chunk[0]["duration_s"] == 1.5 * 60 * 60
+    assert handler.trips_log.chunk[0]["end_s"] == 8 * 60 * 60 + 1.5 * 60 * 60
     assert handler.trips_log.chunk[0]["mode"] == "bus"
 
-    assert handler.activities_log.chunk[1]["start_s"] == 8*60*60 + 1.5*60*60
-    assert handler.activities_log.chunk[1]["duration_s"] == 17.5 * \
-        60*60 - (8*60*60 + 1.5*60*60)
-    assert handler.activities_log.chunk[1]["end_s"] == 17.5*60*60
+    assert handler.activities_log.chunk[1]["start_s"] == 8 * 60 * 60 + 1.5 * 60 * 60
+    assert handler.activities_log.chunk[1]["duration_s"] == 17.5 * 60 * 60 - (
+        8 * 60 * 60 + 1.5 * 60 * 60
+    )
+    assert handler.activities_log.chunk[1]["end_s"] == 17.5 * 60 * 60
     assert handler.activities_log.chunk[1]["act"] == "work"
 
 
 def test_agent_trip_log_process_pt_rail_person(agent_trip_handler):
     handler = agent_trip_handler
-    handler.resources['transit_schedule'].route_to_mode_map["rail_dummy"] = "rail"
+    handler.resources["transit_schedule"].route_to_mode_map["rail_dummy"] = "rail"
 
     person = """
     <person id="nick">
@@ -697,26 +722,27 @@ def test_agent_trip_log_process_pt_rail_person(agent_trip_handler):
     handler.process_plans(person)
 
     assert handler.activities_log.chunk[0]["start_s"] == 0
-    assert handler.activities_log.chunk[0]["duration_s"] == 8*60*60
-    assert handler.activities_log.chunk[0]["end_s"] == 8*60*60
+    assert handler.activities_log.chunk[0]["duration_s"] == 8 * 60 * 60
+    assert handler.activities_log.chunk[0]["end_s"] == 8 * 60 * 60
     assert handler.activities_log.chunk[0]["act"] == "home"
 
-    assert handler.trips_log.chunk[0]["start_s"] == 8*60*60
-    assert handler.trips_log.chunk[0]["duration_s"] == 1.5*60*60
-    assert handler.trips_log.chunk[0]["end_s"] == 8*60*60 + 1.5*60*60
+    assert handler.trips_log.chunk[0]["start_s"] == 8 * 60 * 60
+    assert handler.trips_log.chunk[0]["duration_s"] == 1.5 * 60 * 60
+    assert handler.trips_log.chunk[0]["end_s"] == 8 * 60 * 60 + 1.5 * 60 * 60
     assert handler.trips_log.chunk[0]["mode"] == "rail"
 
-    assert handler.activities_log.chunk[1]["start_s"] == 8*60*60 + 1.5*60*60
-    assert handler.activities_log.chunk[1]["duration_s"] == 17.5 * \
-        60*60 - (8*60*60 + 1.5*60*60)
-    assert handler.activities_log.chunk[1]["end_s"] == 17.5*60*60
+    assert handler.activities_log.chunk[1]["start_s"] == 8 * 60 * 60 + 1.5 * 60 * 60
+    assert handler.activities_log.chunk[1]["duration_s"] == 17.5 * 60 * 60 - (
+        8 * 60 * 60 + 1.5 * 60 * 60
+    )
+    assert handler.activities_log.chunk[1]["end_s"] == 17.5 * 60 * 60
     assert handler.activities_log.chunk[1]["act"] == "work"
 
 
 def test_agent_trip_log_handler(agent_trip_handler):
     handler = agent_trip_handler
 
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for person in plans.persons:
         handler.process_plans(person)
 
@@ -727,7 +753,7 @@ def test_agent_trip_log_handler(agent_trip_handler):
 @pytest.fixture
 def agent_trip_log_handler_finalised(agent_trip_handler):
     handler = agent_trip_handler
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for plan in plans.persons:
         handler.process_plans(plan)
     handler.finalise()
@@ -742,9 +768,10 @@ def test_finalised_logs(agent_trip_log_handler_finalised):
 
 # Plans Wrapping case
 
+
 @pytest.fixture
 def agent_trip_log_handler_bad_plans(test_bad_plans_config, input_bad_plans_manager):
-    handler = plan_handlers.TripLogs(test_bad_plans_config, 'all')
+    handler = plan_handlers.TripLogs(test_bad_plans_config, "all")
 
     resources = input_bad_plans_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -758,11 +785,11 @@ def agent_trip_log_handler_bad_plans(test_bad_plans_config, input_bad_plans_mana
 @pytest.fixture
 def agent_trips_log_handler_finalised_bad_plans(agent_trip_log_handler_bad_plans):
     handler = agent_trip_log_handler_bad_plans
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for plan in plans.persons:
         handler.process_plans(plan)
-    assert handler.activities_log.chunk[-1].get('end_day') == 1
-    assert handler.trips_log.chunk[-1].get('end_day') == 1
+    assert handler.activities_log.chunk[-1].get("end_day") == 1
+    assert handler.trips_log.chunk[-1].get("end_day") == 1
     handler.finalise()
     return handler
 
@@ -775,28 +802,30 @@ def test_finalised_trips_logs_bad_plans(agent_trips_log_handler_finalised_bad_pl
 # Plan Handler ###
 @pytest.fixture
 def agent_plan_handler(test_bad_plans_config, input_manager):
-    handler = plan_handlers.PlanLogs(test_bad_plans_config, 'poor')
+    handler = plan_handlers.PlanLogs(test_bad_plans_config, "poor")
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
-    assert len(handler.plans_log.chunk) == 0
+    assert len(handler.trips_log.chunk) == 0
+    assert len(handler.activities_log.chunk) == 0
     return handler
 
 
 def test_agent_plans_handler(agent_plan_handler):
     handler = agent_plan_handler
 
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for person in plans.persons:
         handler.process_plans(person)
 
-    assert len(handler.plans_log.chunk) == 8
+    assert len(handler.trips_log.chunk) == 10
+    assert len(handler.activities_log.chunk) == 15
 
 
 @pytest.fixture
 def agent_plans_handler_finalised(agent_plan_handler):
     handler = agent_plan_handler
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for plan in plans.persons:
         handler.process_plans(plan)
     handler.finalise()
@@ -811,10 +840,11 @@ def test_finalised_plans(agent_plans_handler_finalised):
 
 # Plans Wrapping case
 
+
 # Bad Config (plans wrap past 24hrs)
 @pytest.fixture
 def agent_plans_handler_bad_plans(test_bad_plans_config, input_bad_plans_manager):
-    handler = plan_handlers.PlanLogs(test_bad_plans_config, 'poor')
+    handler = plan_handlers.PlanLogs(test_bad_plans_config, "poor")
 
     resources = input_bad_plans_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -842,21 +872,20 @@ def agent_plans_handler_bad_plans(test_bad_plans_config, input_bad_plans_manager
 ### Agent Highway Distance Handler ###
 @pytest.fixture
 def agent_distances_handler_car_mode(test_config, input_manager):
-    handler = plan_handlers.AgentHighwayDistanceLogs(test_config, 'car')
+    handler = plan_handlers.AgentHighwayDistanceLogs(test_config, "car")
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
 
-    assert len(handler.agent_ids) == len(
-        handler.resources['subpopulations'].map)
+    assert len(handler.agent_ids) == len(handler.resources["subpopulations"].map)
     assert list(handler.agent_indices.keys()) == handler.agent_ids
 
-    assert len(handler.ways) == len(handler.resources['osm_ways'].classes)
+    assert len(handler.ways) == len(handler.resources["osm_ways"].classes)
     assert list(handler.ways_indices.keys()) == handler.ways
 
     assert handler.distances.shape == (
-        len(handler.resources['subpopulations'].map),
-        len(handler.resources['osm_ways'].classes)
+        len(handler.resources["subpopulations"].map),
+        len(handler.resources["osm_ways"].classes),
     )
 
     return handler
@@ -865,24 +894,23 @@ def agent_distances_handler_car_mode(test_config, input_manager):
 def test_agent_distances_handler_car_mode(agent_distances_handler_car_mode):
     handler = agent_distances_handler_car_mode
 
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for person in plans.persons:
         handler.process_plans(person)
 
     assert np.sum(handler.distances) == 40600.0
 
     # agent
-    assert np.sum(handler.distances[handler.agent_indices['chris']]) == 20400.0
+    assert np.sum(handler.distances[handler.agent_indices["chris"]]) == 20400.0
 
     # class
-    assert np.sum(
-        handler.distances[:, handler.ways_indices['trunk']]) == 30600.0
+    assert np.sum(handler.distances[:, handler.ways_indices["trunk"]]) == 30600.0
 
 
 @pytest.fixture
 def agent_distances_handler_finalised_car(agent_distances_handler_car_mode):
     handler = agent_distances_handler_car_mode
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for plan in plans.persons:
         handler.process_plans(plan)
     handler.finalise()
@@ -894,16 +922,16 @@ def test_finalised_agent_distances_car(agent_distances_handler_finalised_car):
 
     for name, result in handler.results.items():
         cols = handler.ways
-        if 'total' in name:
+        if "total" in name:
             for c in cols:
                 assert c in result.index
-            assert 'total' in result.index
+            assert "total" in result.index
             assert np.sum(result[cols].values) == 40600.0
 
         else:
             for c in cols:
                 assert c in result.columns
-            assert 'total' in result.columns
+            assert "total" in result.columns
             df = result.loc[:, cols]
             assert np.sum(df.values) == 40600.0
 
@@ -911,12 +939,12 @@ def test_finalised_agent_distances_car(agent_distances_handler_finalised_car):
 ### Trips Highway Distance Handler ###
 @pytest.fixture
 def trip_distances_handler_car_mode(test_config, input_manager):
-    handler = plan_handlers.TripHighwayDistanceLogs(test_config, 'car')
+    handler = plan_handlers.TripHighwayDistanceLogs(test_config, "car")
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
 
-    assert len(handler.ways) == len(handler.resources['osm_ways'].classes)
+    assert len(handler.ways) == len(handler.resources["osm_ways"].classes)
 
     return handler
 
@@ -924,22 +952,30 @@ def trip_distances_handler_car_mode(test_config, input_manager):
 def test_trip_distances_handler_car_mode(trip_distances_handler_car_mode):
     handler = trip_distances_handler_car_mode
 
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for person in plans.persons:
         handler.process_plans(person)
 
     assert len(handler.distances_log.chunk) == 10
-    assert sum([d['None'] for d in handler.distances_log.chunk]) == 10000
-    assert sum([d['trunk'] for d in handler.distances_log.chunk]) == 30600
+    assert sum([d["None"] for d in handler.distances_log.chunk]) == 10000
+    assert sum([d["trunk"] for d in handler.distances_log.chunk]) == 30600
 
     # agent
-    assert sum([d['trunk']
-               for d in handler.distances_log.chunk if d['agent_id'] == 'chris']) == 20400.0
+    assert (
+        sum(
+            [
+                d["trunk"]
+                for d in handler.distances_log.chunk
+                if d["agent_id"] == "chris"
+            ]
+        )
+        == 20400.0
+    )
 
 
 def test_trip_distances_handler_finalised_car(trip_distances_handler_car_mode):
     handler = trip_distances_handler_car_mode
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for plan in plans.persons:
         handler.process_plans(plan)
     handler.finalise()
@@ -948,14 +984,15 @@ def test_trip_distances_handler_finalised_car(trip_distances_handler_car_mode):
     results = pd.read_csv(path)
     assert len(results) == 10
     assert sum(results.trunk) == 30600
-    assert sum(results.loc[results.agent_id == 'chris'].trunk) == 20400
+    assert sum(results.loc[results.agent_id == "chris"].trunk) == 20400
 
 
 ### Trip Modeshare Handlers ###
 @pytest.fixture
 def test_trip_modeshare_handler(test_config, input_manager):
     handler = plan_handlers.TripModes(
-        test_config, mode='all', groupby_person_attribute="subpopulation")
+        test_config, mode="all", groupby_person_attribute="subpopulation"
+    )
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -990,7 +1027,7 @@ def test_trip_mode_share_simple(test_trip_modeshare_handler):
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 1
 
 
 def test_trip_mode_share_pt(test_trip_modeshare_handler):
@@ -1020,17 +1057,17 @@ def test_trip_mode_share_pt(test_trip_modeshare_handler):
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['bus']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["bus"]]) == 1
 
 
 def test_trip_distance_mode_share_complex_pt_1(test_trip_modeshare_handler):
     handler = test_trip_modeshare_handler
-    handler.resources['transit_schedule'].route_to_mode_map["rail_dummy"] = "rail"
-    modes = handler.modes + ['rail']
+    handler.resources["transit_schedule"].route_to_mode_map["rail_dummy"] = "rail"
+    modes = handler.modes + ["rail"]
     handler.modes, handler.mode_indices = handler.generate_id_map(modes)
-    handler.mode_counts = np.zeros((len(handler.modes),
-                                    len(handler.classes),
-                                    handler.config.time_periods))
+    handler.mode_counts = np.zeros(
+        (len(handler.modes), len(handler.classes), handler.config.time_periods)
+    )
     string = """
     <person id="nick">
         <plan score="1" selected="yes">
@@ -1061,17 +1098,17 @@ def test_trip_distance_mode_share_complex_pt_1(test_trip_modeshare_handler):
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['rail']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["rail"]]) == 1
 
 
 def test_trip_distance_mode_share_complex_pt_2(test_trip_modeshare_handler):
     handler = test_trip_modeshare_handler
-    handler.resources['transit_schedule'].route_to_mode_map["rail_dummy"] = "rail"
-    modes = handler.modes + ['rail']
+    handler.resources["transit_schedule"].route_to_mode_map["rail_dummy"] = "rail"
+    modes = handler.modes + ["rail"]
     handler.modes, handler.mode_indices = handler.generate_id_map(modes)
-    handler.mode_counts = np.zeros((len(handler.modes),
-                                    len(handler.classes),
-                                    handler.config.time_periods))
+    handler.mode_counts = np.zeros(
+        (len(handler.modes), len(handler.classes), handler.config.time_periods)
+    )
     string = """
     <person id="nick">
         <plan score="1" selected="yes">
@@ -1102,13 +1139,13 @@ def test_trip_distance_mode_share_complex_pt_2(test_trip_modeshare_handler):
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['bus']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["bus"]]) == 1
 
 
 ### Modeshare Handler No Attribute Slices###
 @pytest.fixture
 def test_trip_modeshare_handler_no_attribute_slice(test_config_v12, input_manager):
-    handler = plan_handlers.TripModes(test_config_v12, mode='all')
+    handler = plan_handlers.TripModes(test_config_v12, mode="all")
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -1126,7 +1163,9 @@ def test_trip_modeshare_handler_no_attribute_slice(test_config_v12, input_manage
     return handler
 
 
-def test_trip_mode_share_without_attribute_slice(test_trip_modeshare_handler_no_attribute_slice):
+def test_trip_mode_share_without_attribute_slice(
+    test_trip_modeshare_handler_no_attribute_slice,
+):
     handler = test_trip_modeshare_handler_no_attribute_slice
     string = """
     <person id="nick">
@@ -1150,14 +1189,15 @@ def test_trip_mode_share_without_attribute_slice(test_trip_modeshare_handler_no_
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 1
 
 
 ### Modeshare Handler With Attribute Slices###
 @pytest.fixture
 def test_trip_modeshare_handler_age_attribute_slice(test_config_v12, input_manager_v12):
     handler = plan_handlers.TripModes(
-        test_config_v12, mode='all', groupby_person_attribute="age")
+        test_config_v12, mode="all", groupby_person_attribute="age"
+    )
 
     resources = input_manager_v12.resources
     handler.build(resources, write_path=test_outputs)
@@ -1175,7 +1215,9 @@ def test_trip_modeshare_handler_age_attribute_slice(test_config_v12, input_manag
     return handler
 
 
-def test_trip_mode_share_without_attribute_slice(test_trip_modeshare_handler_age_attribute_slice):
+def test_trip_mode_share_without_attribute_slice(
+    test_trip_modeshare_handler_age_attribute_slice,
+):
     handler = test_trip_modeshare_handler_age_attribute_slice
     string = """
     <person id="nick">
@@ -1221,31 +1263,35 @@ def test_trip_mode_share_without_attribute_slice(test_trip_modeshare_handler_age
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 2
-    assert np.sum(
-        handler.mode_counts[handler.mode_indices['car'], handler.class_indices['yes']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 2
+    assert (
+        np.sum(
+            handler.mode_counts[
+                handler.mode_indices["car"], handler.class_indices["yes"]
+            ]
+        )
+        == 1
+    )
 
 
 def test_trip_handler_test_data(test_trip_modeshare_handler):
     handler = test_trip_modeshare_handler
 
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for person in plans.persons:
         handler.process_plans(person)
 
     assert np.sum(handler.mode_counts) == 10
 
     # mode
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 4
-    assert np.sum(handler.mode_counts[handler.mode_indices['bus']]) == 4
-    assert np.sum(handler.mode_counts[handler.mode_indices['bike']]) == 2
-    assert np.sum(handler.mode_counts[handler.mode_indices['walk']]) == 0
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 4
+    assert np.sum(handler.mode_counts[handler.mode_indices["bus"]]) == 4
+    assert np.sum(handler.mode_counts[handler.mode_indices["bike"]]) == 2
+    assert np.sum(handler.mode_counts[handler.mode_indices["walk"]]) == 0
 
     # class
-    assert np.sum(
-        handler.mode_counts[:, handler.class_indices['rich'], :]) == 2
-    assert np.sum(
-        handler.mode_counts[:, handler.class_indices['poor'], :]) == 8
+    assert np.sum(handler.mode_counts[:, handler.class_indices["rich"], :]) == 2
+    assert np.sum(handler.mode_counts[:, handler.class_indices["poor"], :]) == 8
     # assert np.sum(handler.mode_counts[:, handler.class_indices['not_applicable'], :, :]) == 0
 
     # time
@@ -1256,7 +1302,7 @@ def test_trip_handler_test_data(test_trip_modeshare_handler):
 @pytest.fixture
 def test_trip_modeshares_handler_finalised(test_trip_modeshare_handler):
     handler = test_trip_modeshare_handler
-    plans = handler.resources['plans']
+    plans = handler.resources["plans"]
     for person in plans.persons:
         handler.process_plans(person)
     handler.finalise()
@@ -1267,10 +1313,9 @@ def test_finalised_trip_mode_counts(test_trip_modeshares_handler_finalised):
     handler = test_trip_modeshares_handler_finalised
 
     for name, result in handler.results.items():
-        if 'counts' in name:
+        if "counts" in name:
             if isinstance(result, pd.DataFrame):
-                assert result["count"].sum() == 10 / \
-                    handler.config.scale_factor
+                assert result["count"].sum() == 10 / handler.config.scale_factor
             else:
                 assert result.sum() == 10 / handler.config.scale_factor
 
@@ -1283,9 +1328,12 @@ def test_finalised_trip_mode_counts(test_trip_modeshares_handler_finalised):
 
 ### TripDestinationModeShare Modeshare Handler No Attribute Slices###
 @pytest.fixture
-def test_trip_activity_modeshare_handler_without_attribute_slice(test_config_v12, input_manager_v12):
+def test_trip_activity_modeshare_handler_without_attribute_slice(
+    test_config_v12, input_manager_v12
+):
     handler = plan_handlers.TripActivityModes(
-        test_config_v12, mode='all', destination_activity_filters=["work_a", "work_b"])
+        test_config_v12, mode="all", destination_activity_filters=["work_a", "work_b"]
+    )
 
     resources = input_manager_v12.resources
     handler.build(resources, write_path=test_outputs)
@@ -1302,9 +1350,12 @@ def test_trip_activity_modeshare_handler_without_attribute_slice(test_config_v12
 
 
 @pytest.fixture
-def test_trip_pt_interaction_modeshare_handler_without_attribute_slice(test_config_v12, input_manager_v12):
+def test_trip_pt_interaction_modeshare_handler_without_attribute_slice(
+    test_config_v12, input_manager_v12
+):
     handler = plan_handlers.TripActivityModes(
-        test_config_v12, mode='all', destination_activity_filters=["pt interaction"])
+        test_config_v12, mode="all", destination_activity_filters=["pt interaction"]
+    )
 
     resources = input_manager_v12.resources
     handler.build(resources, write_path=test_outputs)
@@ -1320,7 +1371,9 @@ def test_trip_pt_interaction_modeshare_handler_without_attribute_slice(test_conf
     return handler
 
 
-def test_trip_activity_mode_share_without_attribute_slice_with_activities_simple(test_trip_activity_modeshare_handler_without_attribute_slice):
+def test_trip_activity_mode_share_without_attribute_slice_with_activities_simple(
+    test_trip_activity_modeshare_handler_without_attribute_slice,
+):
     handler = test_trip_activity_modeshare_handler_without_attribute_slice
     string = """
     <person id="alex">
@@ -1344,10 +1397,12 @@ def test_trip_activity_mode_share_without_attribute_slice_with_activities_simple
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 1
 
 
-def test_trip_activity_mode_share_without_attribute_slice_with_activities_complex(test_trip_activity_modeshare_handler_without_attribute_slice):
+def test_trip_activity_mode_share_without_attribute_slice_with_activities_complex(
+    test_trip_activity_modeshare_handler_without_attribute_slice,
+):
     handler = test_trip_activity_modeshare_handler_without_attribute_slice
     string = """
     <person id="varun">
@@ -1461,11 +1516,13 @@ def test_trip_activity_mode_share_without_attribute_slice_with_activities_comple
     person = etree.fromstring(string)
     handler.process_plans(person)
 
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 2
-    assert np.sum(handler.mode_counts[handler.mode_indices['walk']]) == 3
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 2
+    assert np.sum(handler.mode_counts[handler.mode_indices["walk"]]) == 3
 
 
-def test_trip_activity_mode_share_without_attribute_slice_with_activities_pt_interaction(test_trip_pt_interaction_modeshare_handler_without_attribute_slice):
+def test_trip_activity_mode_share_without_attribute_slice_with_activities_pt_interaction(
+    test_trip_pt_interaction_modeshare_handler_without_attribute_slice,
+):
     handler = test_trip_pt_interaction_modeshare_handler_without_attribute_slice
 
     string = """
@@ -1517,15 +1574,19 @@ def test_trip_activity_mode_share_without_attribute_slice_with_activities_pt_int
     person = etree.fromstring(string)
     handler.process_plans(person)
 
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 0
-    assert np.sum(handler.mode_counts[handler.mode_indices['walk']]) == 1
-    assert np.sum(handler.mode_counts[handler.mode_indices['bus']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 0
+    assert np.sum(handler.mode_counts[handler.mode_indices["walk"]]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["bus"]]) == 1
 
 
 @pytest.fixture
 def test_trip_work_and_education_activity_modeshare_handler(test_config, input_manager):
     handler = plan_handlers.TripActivityModes(
-        test_config, mode='all', groupby_person_attribute="subpopulation", destination_activity_filters=["work", "education"])
+        test_config,
+        mode="all",
+        groupby_person_attribute="subpopulation",
+        destination_activity_filters=["work", "education"],
+    )
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -1537,14 +1598,16 @@ def test_trip_work_and_education_activity_modeshare_handler(test_config, input_m
     return handler
 
 
-def test_trip_work_mode_share_with_destination_activities_filter(test_trip_work_and_education_activity_modeshare_handler):
+def test_trip_work_mode_share_with_destination_activities_filter(
+    test_trip_work_and_education_activity_modeshare_handler,
+):
     handler = test_trip_work_and_education_activity_modeshare_handler
-    handler.resources['transit_schedule'].route_to_mode_map["rail_dummy"] = "rail"
-    modes = handler.modes + ['rail']
+    handler.resources["transit_schedule"].route_to_mode_map["rail_dummy"] = "rail"
+    modes = handler.modes + ["rail"]
     handler.modes, handler.mode_indices = handler.generate_id_map(modes)
-    handler.mode_counts = np.zeros((len(handler.modes),
-                                    len(handler.classes),
-                                    handler.config.time_periods))
+    handler.mode_counts = np.zeros(
+        (len(handler.modes), len(handler.classes), handler.config.time_periods)
+    )
     stringA = """
     <person id="nick">
         <plan score="1" selected="yes">
@@ -1605,17 +1668,19 @@ def test_trip_work_mode_share_with_destination_activities_filter(test_trip_work_
     personB = etree.fromstring(stringB)
     handler.process_plans(personA)
     handler.process_plans(personB)
-    assert np.sum(handler.mode_counts[handler.mode_indices['bus']]) == 2
+    assert np.sum(handler.mode_counts[handler.mode_indices["bus"]]) == 2
 
 
 ### TripDestinationModeShare Handler With Attribute Slices###
 @pytest.fixture
-def test_trip_activity_modeshare_handler_age_attribute_slice(test_config_v12, input_manager_v12):
+def test_trip_activity_modeshare_handler_age_attribute_slice(
+    test_config_v12, input_manager_v12
+):
     handler = plan_handlers.TripActivityModes(
         test_config_v12,
-        mode='all',
+        mode="all",
         destination_activity_filters=["work_a", "work_b"],
-        groupby_person_attribute="age"
+        groupby_person_attribute="age",
     )
 
     resources = input_manager_v12.resources
@@ -1634,7 +1699,9 @@ def test_trip_activity_modeshare_handler_age_attribute_slice(test_config_v12, in
     return handler
 
 
-def test_trip_activity_mode_share_with_attribute_slice(test_trip_activity_modeshare_handler_age_attribute_slice):
+def test_trip_activity_mode_share_with_attribute_slice(
+    test_trip_activity_modeshare_handler_age_attribute_slice,
+):
     handler = test_trip_activity_modeshare_handler_age_attribute_slice
     string = """
     <person id="nick">
@@ -1681,17 +1748,25 @@ def test_trip_activity_mode_share_with_attribute_slice(test_trip_activity_modesh
     person = etree.fromstring(string)
     handler.process_plans(person)
     # mode
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 2
-    assert np.sum(
-        handler.mode_counts[handler.mode_indices['car'], handler.class_indices['yes']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 2
+    assert (
+        np.sum(
+            handler.mode_counts[
+                handler.mode_indices["car"], handler.class_indices["yes"]
+            ]
+        )
+        == 1
+    )
 
     # class
-    assert np.sum(handler.mode_counts[:, handler.class_indices['yes'], :]) == 1
-    assert np.sum(handler.mode_counts[:, handler.class_indices['no'], :]) == 1
+    assert np.sum(handler.mode_counts[:, handler.class_indices["yes"], :]) == 1
+    assert np.sum(handler.mode_counts[:, handler.class_indices["no"], :]) == 1
 
 
 @pytest.fixture
-def test_trip_activity_modeshare_plan_handler_finalised(test_trip_activity_modeshare_handler_age_attribute_slice):
+def test_trip_activity_modeshare_plan_handler_finalised(
+    test_trip_activity_modeshare_handler_age_attribute_slice,
+):
     handler = test_trip_activity_modeshare_handler_age_attribute_slice
     # plans = test_plan_activity_modeshare_handler_age_attribute_slice.resources['plans']
 
@@ -1745,10 +1820,12 @@ def test_trip_activity_modeshare_plan_handler_finalised(test_trip_activity_modes
     return handler
 
 
-def test_trip_activity_finalised_mode_counts(test_trip_activity_modeshare_plan_handler_finalised):
+def test_trip_activity_finalised_mode_counts(
+    test_trip_activity_modeshare_plan_handler_finalised,
+):
     handler = test_trip_activity_modeshare_plan_handler_finalised
     for name, result in handler.results.items():
-        if 'counts' in name:
+        if "counts" in name:
             if isinstance(result, pd.DataFrame):
                 assert result["count"].sum() == 2 / handler.config.scale_factor
             else:
@@ -1765,7 +1842,8 @@ def test_trip_activity_finalised_mode_counts(test_trip_activity_modeshare_plan_h
 @pytest.fixture
 def test_plan_modeshare_handler(test_config, input_manager):
     handler = plan_handlers.PlanModes(
-        test_config, mode='all', groupby_person_attribute="subpopulation")
+        test_config, mode="all", groupby_person_attribute="subpopulation"
+    )
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -1799,7 +1877,7 @@ def test_plan_mode_share_simple(test_plan_modeshare_handler):
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 1
 
 
 def test_plan_mode_share_pt(test_plan_modeshare_handler):
@@ -1834,17 +1912,17 @@ def test_plan_mode_share_pt(test_plan_modeshare_handler):
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['bus']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["bus"]]) == 1
 
 
 def test_plan_mode_share_complex_pt_1(test_plan_modeshare_handler):
     handler = test_plan_modeshare_handler
-    handler.resources['transit_schedule'].route_to_mode_map["rail_dummy"] = "rail"
-    modes = handler.modes + ['rail']
+    handler.resources["transit_schedule"].route_to_mode_map["rail_dummy"] = "rail"
+    modes = handler.modes + ["rail"]
     handler.modes, handler.mode_indices = handler.generate_id_map(modes)
-    handler.mode_counts = np.zeros((len(handler.modes),
-                                    len(handler.classes),
-                                    handler.config.time_periods))
+    handler.mode_counts = np.zeros(
+        (len(handler.modes), len(handler.classes), handler.config.time_periods)
+    )
     string = """
     <person id="nick">
         <plan score="1" selected="yes">
@@ -1880,17 +1958,17 @@ def test_plan_mode_share_complex_pt_1(test_plan_modeshare_handler):
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['rail']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["rail"]]) == 1
 
 
 def test_distance_mode_share_complex_pt_2(test_plan_modeshare_handler):
     handler = test_plan_modeshare_handler
-    handler.resources['transit_schedule'].route_to_mode_map["rail_dummy"] = "rail"
-    modes = handler.modes + ['rail']
+    handler.resources["transit_schedule"].route_to_mode_map["rail_dummy"] = "rail"
+    modes = handler.modes + ["rail"]
     handler.modes, handler.mode_indices = handler.generate_id_map(modes)
-    handler.mode_counts = np.zeros((len(handler.modes),
-                                    len(handler.classes),
-                                    handler.config.time_periods))
+    handler.mode_counts = np.zeros(
+        (len(handler.modes), len(handler.classes), handler.config.time_periods)
+    )
     string = """
     <person id="nick">
         <plan score="1" selected="yes">
@@ -1926,13 +2004,13 @@ def test_distance_mode_share_complex_pt_2(test_plan_modeshare_handler):
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['bus']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["bus"]]) == 1
 
 
 ### Modeshare Handler No Attribute Slices###
 @pytest.fixture
 def test_plan_modeshare_handler_no_attribute_slice(test_config_v12, input_manager):
-    handler = plan_handlers.PlanModes(test_config_v12, mode='all')
+    handler = plan_handlers.PlanModes(test_config_v12, mode="all")
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -1944,7 +2022,9 @@ def test_plan_modeshare_handler_no_attribute_slice(test_config_v12, input_manage
     return handler
 
 
-def test_plan_mode_share_without_attribute_slice(test_plan_modeshare_handler_no_attribute_slice):
+def test_plan_mode_share_without_attribute_slice(
+    test_plan_modeshare_handler_no_attribute_slice,
+):
     handler = test_plan_modeshare_handler_no_attribute_slice
     string = """
     <person id="nick">
@@ -1973,14 +2053,15 @@ def test_plan_mode_share_without_attribute_slice(test_plan_modeshare_handler_no_
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 1
 
 
 ### Modeshare Handler With Attribute Slices###
 @pytest.fixture
 def test_plan_modeshare_handler_age_attribute_slice(test_config_v12, input_manager_v12):
     handler = plan_handlers.TripModes(
-        test_config_v12, mode='all', groupby_person_attribute="age")
+        test_config_v12, mode="all", groupby_person_attribute="age"
+    )
 
     resources = input_manager_v12.resources
     handler.build(resources, write_path=test_outputs)
@@ -1992,7 +2073,9 @@ def test_plan_modeshare_handler_age_attribute_slice(test_config_v12, input_manag
     return handler
 
 
-def test_plan_mode_share_without_attribute_slice(test_plan_modeshare_handler_age_attribute_slice):
+def test_plan_mode_share_without_attribute_slice(
+    test_plan_modeshare_handler_age_attribute_slice,
+):
     handler = test_plan_modeshare_handler_age_attribute_slice
     string = """
     <person id="nick">
@@ -2038,37 +2121,41 @@ def test_plan_mode_share_without_attribute_slice(test_plan_modeshare_handler_age
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 2
-    assert np.sum(
-        handler.mode_counts[handler.mode_indices['car'], handler.class_indices['yes']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 2
+    assert (
+        np.sum(
+            handler.mode_counts[
+                handler.mode_indices["car"], handler.class_indices["yes"]
+            ]
+        )
+        == 1
+    )
 
 
 def test_plan_handler_test_data(test_plan_modeshare_handler):
     handler = test_plan_modeshare_handler
 
-    plans = test_plan_modeshare_handler.resources['plans']
+    plans = test_plan_modeshare_handler.resources["plans"]
     for person in plans.persons:
         handler.process_plans(person)
 
     assert np.sum(handler.mode_counts) == 5
 
     # mode
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 2
-    assert np.sum(handler.mode_counts[handler.mode_indices['bus']]) == 2
-    assert np.sum(handler.mode_counts[handler.mode_indices['bike']]) == 1
-    assert np.sum(handler.mode_counts[handler.mode_indices['walk']]) == 0
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 2
+    assert np.sum(handler.mode_counts[handler.mode_indices["bus"]]) == 2
+    assert np.sum(handler.mode_counts[handler.mode_indices["bike"]]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["walk"]]) == 0
 
     # class
-    assert np.sum(
-        handler.mode_counts[:, handler.class_indices['rich'], :]) == 1
-    assert np.sum(
-        handler.mode_counts[:, handler.class_indices['poor'], :]) == 4
+    assert np.sum(handler.mode_counts[:, handler.class_indices["rich"], :]) == 1
+    assert np.sum(handler.mode_counts[:, handler.class_indices["poor"], :]) == 4
 
 
 @pytest.fixture
 def test_plan_handler_finalised(test_plan_modeshare_handler):
     handler = test_plan_modeshare_handler
-    plans = test_plan_modeshare_handler.resources['plans']
+    plans = test_plan_modeshare_handler.resources["plans"]
     for person in plans.persons:
         handler.process_plans(person)
     handler.finalise()
@@ -2079,7 +2166,7 @@ def test_finalised_plan_mode_counts(test_plan_handler_finalised):
     handler = test_plan_handler_finalised
 
     for name, result in handler.results.items():
-        if 'counts' in name:
+        if "counts" in name:
             if isinstance(result, pd.DataFrame):
                 assert result["count"].sum() == 5 / handler.config.scale_factor
             else:
@@ -2094,9 +2181,12 @@ def test_finalised_plan_mode_counts(test_plan_handler_finalised):
 
 ### TripDestinationModeShare Modeshare Handler No Attribute Slices###
 @pytest.fixture
-def test_plan_activity_modeshare_handler_without_attribute_slice(test_config_v12, input_manager_v12):
+def test_plan_activity_modeshare_handler_without_attribute_slice(
+    test_config_v12, input_manager_v12
+):
     handler = plan_handlers.TripActivityModes(
-        test_config_v12, mode='all', destination_activity_filters=["work_a", "work_b"])
+        test_config_v12, mode="all", destination_activity_filters=["work_a", "work_b"]
+    )
 
     resources = input_manager_v12.resources
     handler.build(resources, write_path=test_outputs)
@@ -2112,7 +2202,9 @@ def test_plan_activity_modeshare_handler_without_attribute_slice(test_config_v12
     return handler
 
 
-def test_activity_plan_mode_share_without_attribute_slice_with_activities_simple(test_plan_activity_modeshare_handler_without_attribute_slice):
+def test_activity_plan_mode_share_without_attribute_slice_with_activities_simple(
+    test_plan_activity_modeshare_handler_without_attribute_slice,
+):
     handler = test_plan_activity_modeshare_handler_without_attribute_slice
     string = """
     <person id="alex">
@@ -2136,10 +2228,12 @@ def test_activity_plan_mode_share_without_attribute_slice_with_activities_simple
     """
     person = etree.fromstring(string)
     handler.process_plans(person)
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 1
 
 
-def test_activity_plan_mode_share_without_attribute_slice_with_activities_complex(test_plan_activity_modeshare_handler_without_attribute_slice):
+def test_activity_plan_mode_share_without_attribute_slice_with_activities_complex(
+    test_plan_activity_modeshare_handler_without_attribute_slice,
+):
     handler = test_plan_activity_modeshare_handler_without_attribute_slice
     string = """
     <person id="varun">
@@ -2253,14 +2347,18 @@ def test_activity_plan_mode_share_without_attribute_slice_with_activities_comple
     person = etree.fromstring(string)
     handler.process_plans(person)
 
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 2
-    assert np.sum(handler.mode_counts[handler.mode_indices['walk']]) == 3
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 2
+    assert np.sum(handler.mode_counts[handler.mode_indices["walk"]]) == 3
 
 
 @pytest.fixture
 def test_work_and_education_plan_activity_modeshare_handler(test_config, input_manager):
     handler = plan_handlers.TripActivityModes(
-        test_config, mode='all', groupby_person_attribute="subpopulation", destination_activity_filters=["work", "education"])
+        test_config,
+        mode="all",
+        groupby_person_attribute="subpopulation",
+        destination_activity_filters=["work", "education"],
+    )
 
     resources = input_manager.resources
     handler.build(resources, write_path=test_outputs)
@@ -2272,14 +2370,16 @@ def test_work_and_education_plan_activity_modeshare_handler(test_config, input_m
     return handler
 
 
-def test_work_plan_mode_share_with_destination_activities_filter(test_work_and_education_plan_activity_modeshare_handler):
+def test_work_plan_mode_share_with_destination_activities_filter(
+    test_work_and_education_plan_activity_modeshare_handler,
+):
     handler = test_work_and_education_plan_activity_modeshare_handler
-    handler.resources['transit_schedule'].route_to_mode_map["rail_dummy"] = "rail"
-    modes = handler.modes + ['rail']
+    handler.resources["transit_schedule"].route_to_mode_map["rail_dummy"] = "rail"
+    modes = handler.modes + ["rail"]
     handler.modes, handler.mode_indices = handler.generate_id_map(modes)
-    handler.mode_counts = np.zeros((len(handler.modes),
-                                    len(handler.classes),
-                                    handler.config.time_periods))
+    handler.mode_counts = np.zeros(
+        (len(handler.modes), len(handler.classes), handler.config.time_periods)
+    )
     stringA = """
     <person id="nick">
         <plan score="1" selected="yes">
@@ -2340,17 +2440,19 @@ def test_work_plan_mode_share_with_destination_activities_filter(test_work_and_e
     personB = etree.fromstring(stringB)
     handler.process_plans(personA)
     handler.process_plans(personB)
-    assert np.sum(handler.mode_counts[handler.mode_indices['bus']]) == 2
+    assert np.sum(handler.mode_counts[handler.mode_indices["bus"]]) == 2
 
 
 ### PlanActivityModeShare Handler With Attribute Slices###
 @pytest.fixture
-def test_plan_activity_modeshare_handler_age_attribute_slice(test_config_v12, input_manager_v12):
+def test_plan_activity_modeshare_handler_age_attribute_slice(
+    test_config_v12, input_manager_v12
+):
     handler = plan_handlers.PlanActivityModes(
         test_config_v12,
-        mode='all',
+        mode="all",
         destination_activity_filters=["work_a", "work_b"],
-        groupby_person_attribute="age"
+        groupby_person_attribute="age",
     )
 
     resources = input_manager_v12.resources
@@ -2369,7 +2471,9 @@ def test_plan_activity_modeshare_handler_age_attribute_slice(test_config_v12, in
     return handler
 
 
-def test_plan_activity_mode_share_with_attribute_slice(test_plan_activity_modeshare_handler_age_attribute_slice):
+def test_plan_activity_mode_share_with_attribute_slice(
+    test_plan_activity_modeshare_handler_age_attribute_slice,
+):
     handler = test_plan_activity_modeshare_handler_age_attribute_slice
     string = """
     <person id="nick">
@@ -2416,17 +2520,25 @@ def test_plan_activity_mode_share_with_attribute_slice(test_plan_activity_modesh
     person = etree.fromstring(string)
     handler.process_plans(person)
     # mode
-    assert np.sum(handler.mode_counts[handler.mode_indices['car']]) == 2
-    assert np.sum(
-        handler.mode_counts[handler.mode_indices['car'], handler.class_indices['yes']]) == 1
+    assert np.sum(handler.mode_counts[handler.mode_indices["car"]]) == 2
+    assert (
+        np.sum(
+            handler.mode_counts[
+                handler.mode_indices["car"], handler.class_indices["yes"]
+            ]
+        )
+        == 1
+    )
 
     # class
-    assert np.sum(handler.mode_counts[:, handler.class_indices['yes'], :]) == 1
-    assert np.sum(handler.mode_counts[:, handler.class_indices['no'], :]) == 1
+    assert np.sum(handler.mode_counts[:, handler.class_indices["yes"], :]) == 1
+    assert np.sum(handler.mode_counts[:, handler.class_indices["no"], :]) == 1
 
 
 @pytest.fixture
-def test_plan_activity_modeshare_plan_handler_finalised(test_plan_activity_modeshare_handler_age_attribute_slice):
+def test_plan_activity_modeshare_plan_handler_finalised(
+    test_plan_activity_modeshare_handler_age_attribute_slice,
+):
     handler = test_plan_activity_modeshare_handler_age_attribute_slice
     # plans = test_plan_activity_modeshare_handler_age_attribute_slice.resources['plans']
 
@@ -2488,10 +2600,12 @@ def test_plan_activity_modeshare_plan_handler_finalised(test_plan_activity_modes
     return handler
 
 
-def test_plan_activity_finalised_mode_counts(test_plan_activity_modeshare_plan_handler_finalised):
+def test_plan_activity_finalised_mode_counts(
+    test_plan_activity_modeshare_plan_handler_finalised,
+):
     handler = test_plan_activity_modeshare_plan_handler_finalised
     for name, result in handler.results.items():
-        if 'counts' in name:
+        if "counts" in name:
             if isinstance(result, pd.DataFrame):
                 assert result["count"].sum() == 2 / handler.config.scale_factor
             else:
@@ -2502,6 +2616,7 @@ def test_plan_activity_finalised_mode_counts(test_plan_activity_modeshare_plan_h
                 assert result.share.sum() == 1
             else:
                 assert result.sum() == 1
+
 
 # Plan Handler Manager
 
@@ -2516,54 +2631,60 @@ def test_load_workstation_with_trip_modes(test_config, test_paths):
     plan_workstation.connect(managers=None, suppliers=[input_workstation])
 
     # mode_share
-    tool = plan_workstation.tools['trip_modes']
-    plan_workstation.resources['trip_modes'] = tool(
-        test_config,
-        mode='all',
-        groupby_person_attribute="subpopulation"
+    tool = plan_workstation.tools["trip_modes"]
+    plan_workstation.resources["trip_modes"] = tool(
+        test_config, mode="all", groupby_person_attribute="subpopulation"
     )
 
     # detination based mode_share
-    tool = plan_workstation.tools['trip_activity_modes']
-    plan_workstation.resources['trip_activity_modes'] = tool(
-        test_config,
-        'all',
-        destination_activity_filters=["work"]
+    tool = plan_workstation.tools["trip_activity_modes"]
+    plan_workstation.resources["trip_activity_modes"] = tool(
+        test_config, "all", destination_activity_filters=["work"]
     )
 
     # detination and attribute based mode_share
-    tool = plan_workstation.tools['trip_activity_modes']
-    plan_workstation.resources['trip_activity_modes'] = tool(
+    tool = plan_workstation.tools["trip_activity_modes"]
+    plan_workstation.resources["trip_activity_modes"] = tool(
         test_config,
-        'all',
+        "all",
         destination_activity_filters=["work"],
-        groupby_person_attribute="subpopulation"
+        groupby_person_attribute="subpopulation",
     )
 
     plan_workstation.build(write_path=test_outputs)
 
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_modes_all_detailed_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_modes_all_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_modes_all_detailed_shares.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_modes_all_shares.csv"))
+    assert os.path.exists(
+        os.path.join(test_outputs, "trip_modes_all_detailed_counts.csv")
+    )
+    assert os.path.exists(os.path.join(test_outputs, "trip_modes_all_counts.csv"))
+    assert os.path.exists(
+        os.path.join(test_outputs, "trip_modes_all_detailed_shares.csv")
+    )
+    assert os.path.exists(os.path.join(test_outputs, "trip_modes_all_shares.csv"))
 
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_activity_modes_all_work_detailed_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_activity_modes_all_work_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_activity_modes_all_work_shares.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_activity_modes_all_work_detailed_shares.csv"))
+    assert os.path.exists(
+        os.path.join(test_outputs, "trip_activity_modes_all_work_detailed_counts.csv")
+    )
+    assert os.path.exists(
+        os.path.join(test_outputs, "trip_activity_modes_all_work_counts.csv")
+    )
+    assert os.path.exists(
+        os.path.join(test_outputs, "trip_activity_modes_all_work_shares.csv")
+    )
+    assert os.path.exists(
+        os.path.join(test_outputs, "trip_activity_modes_all_work_detailed_shares.csv")
+    )
 
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_activity_modes_all_work_subpopulation_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_activity_modes_all_work_subpopulation_shares.csv"))
+    assert os.path.exists(
+        os.path.join(
+            test_outputs, "trip_activity_modes_all_work_subpopulation_counts.csv"
+        )
+    )
+    assert os.path.exists(
+        os.path.join(
+            test_outputs, "trip_activity_modes_all_work_subpopulation_shares.csv"
+        )
+    )
 
 
 def test_load_workstation_with_plan_modes(test_config, test_paths):
@@ -2576,54 +2697,60 @@ def test_load_workstation_with_plan_modes(test_config, test_paths):
     plan_workstation.connect(managers=None, suppliers=[input_workstation])
 
     # mode_share
-    tool = plan_workstation.tools['plan_modes']
-    plan_workstation.resources['plan_modes'] = tool(
-        test_config,
-        mode='all',
-        groupby_person_attribute="subpopulation"
+    tool = plan_workstation.tools["plan_modes"]
+    plan_workstation.resources["plan_modes"] = tool(
+        test_config, mode="all", groupby_person_attribute="subpopulation"
     )
 
     # detination based mode_share
-    tool = plan_workstation.tools['plan_activity_modes']
-    plan_workstation.resources['plan_activity_modes'] = tool(
-        test_config,
-        'all',
-        destination_activity_filters=["work"]
+    tool = plan_workstation.tools["plan_activity_modes"]
+    plan_workstation.resources["plan_activity_modes"] = tool(
+        test_config, "all", destination_activity_filters=["work"]
     )
 
     # detination and attribute based mode_share
-    tool = plan_workstation.tools['plan_activity_modes']
-    plan_workstation.resources['plan_activity_modes'] = tool(
+    tool = plan_workstation.tools["plan_activity_modes"]
+    plan_workstation.resources["plan_activity_modes"] = tool(
         test_config,
-        'all',
+        "all",
         destination_activity_filters=["work"],
-        groupby_person_attribute="subpopulation"
+        groupby_person_attribute="subpopulation",
     )
 
     plan_workstation.build(write_path=test_outputs)
 
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_modes_all_detailed_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_modes_all_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_modes_all_detailed_shares.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_modes_all_shares.csv"))
+    assert os.path.exists(
+        os.path.join(test_outputs, "plan_modes_all_detailed_counts.csv")
+    )
+    assert os.path.exists(os.path.join(test_outputs, "plan_modes_all_counts.csv"))
+    assert os.path.exists(
+        os.path.join(test_outputs, "plan_modes_all_detailed_shares.csv")
+    )
+    assert os.path.exists(os.path.join(test_outputs, "plan_modes_all_shares.csv"))
 
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_activity_modes_all_work_detailed_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_activity_modes_all_work_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_activity_modes_all_work_shares.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_activity_modes_all_work_detailed_shares.csv"))
+    assert os.path.exists(
+        os.path.join(test_outputs, "plan_activity_modes_all_work_detailed_counts.csv")
+    )
+    assert os.path.exists(
+        os.path.join(test_outputs, "plan_activity_modes_all_work_counts.csv")
+    )
+    assert os.path.exists(
+        os.path.join(test_outputs, "plan_activity_modes_all_work_shares.csv")
+    )
+    assert os.path.exists(
+        os.path.join(test_outputs, "plan_activity_modes_all_work_detailed_shares.csv")
+    )
 
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_activity_modes_all_work_subpopulation_counts.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "plan_activity_modes_all_work_subpopulation_shares.csv"))
+    assert os.path.exists(
+        os.path.join(
+            test_outputs, "plan_activity_modes_all_work_subpopulation_counts.csv"
+        )
+    )
+    assert os.path.exists(
+        os.path.join(
+            test_outputs, "plan_activity_modes_all_work_subpopulation_shares.csv"
+        )
+    )
 
 
 def test_load_workstation_with_logs(test_config, test_paths):
@@ -2636,31 +2763,28 @@ def test_load_workstation_with_logs(test_config, test_paths):
     plan_workstation.connect(managers=None, suppliers=[input_workstation])
 
     # leg_logs
-    plan_workstation.resources['leg_logs'] = plan_workstation.tools['leg_logs'](
+    plan_workstation.resources["leg_logs"] = plan_workstation.tools["leg_logs"](
         test_config,
-        mode='all',
+        mode="all",
     )
 
     # trip_logs
-    plan_workstation.resources['trip_logs'] = plan_workstation.tools['trip_logs'](
+    plan_workstation.resources["trip_logs"] = plan_workstation.tools["trip_logs"](
         test_config,
-        mode='all',
+        mode="all",
     )
 
     plan_workstation.build(write_path=test_outputs)
 
     assert os.path.exists(os.path.join(test_outputs, "leg_logs_all_legs.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "leg_logs_all_activities.csv"))
+    assert os.path.exists(os.path.join(test_outputs, "leg_logs_all_activities.csv"))
 
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_logs_all_trips.csv"))
-    assert os.path.exists(os.path.join(
-        test_outputs, "trip_logs_all_activities.csv"))
+    assert os.path.exists(os.path.join(test_outputs, "trip_logs_all_trips.csv"))
+    assert os.path.exists(os.path.join(test_outputs, "trip_logs_all_activities.csv"))
 
 
 def test_non_zero_pt_interaction_legs(agent_leg_log_handler):
-    """ PT interaction activity has non-zero duration """
+    """PT interaction activity has non-zero duration"""
 
     handler = agent_leg_log_handler
 
@@ -2695,11 +2819,11 @@ def test_non_zero_pt_interaction_legs(agent_leg_log_handler):
 
     person = etree.fromstring(person)
     handler.process_plans(person)
-    assert handler.legs_log.chunk[-1]['start_s'] == 63000
+    assert handler.legs_log.chunk[-1]["start_s"] == 63000
 
 
 def test_zero_pt_interaction_legs(agent_leg_log_handler):
-    """ PT interaction activity has zero duration (not 'end_time' attribute in the 'pt interaction' activity ) """
+    """PT interaction activity has zero duration (not 'end_time' attribute in the 'pt interaction' activity )"""
 
     handler = agent_leg_log_handler
 
@@ -2734,11 +2858,11 @@ def test_zero_pt_interaction_legs(agent_leg_log_handler):
 
     person = etree.fromstring(person)
     handler.process_plans(person)
-    assert handler.legs_log.chunk[-1]['start_s'] == 28804
+    assert handler.legs_log.chunk[-1]["start_s"] == 28804
 
 
 def test_non_zero_pt_interaction_trips(agent_trip_handler):
-    """ PT interaction activity has non-zero duration """
+    """PT interaction activity has non-zero duration"""
 
     handler = agent_trip_handler
 
@@ -2773,11 +2897,11 @@ def test_non_zero_pt_interaction_trips(agent_trip_handler):
 
     person = etree.fromstring(person)
     handler.process_plans(person)
-    assert handler.trips_log.chunk[-1]['end_s'] == 63454
+    assert handler.trips_log.chunk[-1]["end_s"] == 63454
 
 
 def test_zero_pt_interaction_trips(agent_trip_handler):
-    """ PT interaction activity has zero duration """
+    """PT interaction activity has zero duration"""
 
     handler = agent_trip_handler
 
@@ -2812,11 +2936,11 @@ def test_zero_pt_interaction_trips(agent_trip_handler):
 
     person = etree.fromstring(person)
     handler.process_plans(person)
-    assert handler.trips_log.chunk[-1]['end_s'] == 29258
+    assert handler.trips_log.chunk[-1]["end_s"] == 29258
 
 
 def test_non_zero_pt_interaction_plan(agent_plan_handler):
-    """ PT interaction activity has non-zero duration, plan logs """
+    """PT interaction activity has non-zero duration, plan logs"""
 
     handler = agent_plan_handler
 
@@ -2851,13 +2975,12 @@ def test_non_zero_pt_interaction_plan(agent_plan_handler):
 
     person = etree.fromstring(person)
     handler.process_plans(person)
-    assert len(handler.plans_log.chunk) == 1
-    assert handler.plans_log.chunk[0]['act_duration'] == 22945
-    assert handler.plans_log.chunk[0]['start'] == 28800
+    assert len(handler.trips_log.chunk) == 1
+    assert handler.trips_log.chunk[0]["duration_s"] == 34654.0
 
 
 def test_zero_pt_interaction_plan(agent_plan_handler):
-    """ PT interaction activity has zero duration, plan logs """
+    """PT interaction activity has zero duration, plan logs"""
 
     handler = agent_plan_handler
 
@@ -2892,6 +3015,5 @@ def test_zero_pt_interaction_plan(agent_plan_handler):
 
     person = etree.fromstring(person)
     handler.process_plans(person)
-    assert len(handler.plans_log.chunk) == 1
-    assert handler.plans_log.chunk[0]['act_duration'] == 57141
-    assert handler.plans_log.chunk[0]['start'] == 28800
+    assert len(handler.trips_log.chunk) == 1
+    assert handler.trips_log.chunk[0]["duration_s"] == 458.0


### PR DESCRIPTION
Fix for #236.

Overhauls the PlanLogs handler. It is now a (mostly) copy paste of the more commonly used trips log handler but with plan id, selection and score added.

I am pretty sure this has the info required for SEE analysis?

Example:
```
,agent_id,attribute,plan,selected,score,seq,mode,ox,oy,dx,dy,o_act,d_act,start,start_day,end,end_day,start_s,end_s,duration,duration_s,distance
0,chris,rich,0,yes,129.464432800573,1,car,0.0,0.0,10100.0,0.0,home,work,07:00:00,1,07:07:34,1,25200,25654,0 days 00:07:34,454.0,10100.0
1,chris,rich,0,yes,129.464432800573,2,car,10100.0,0.0,0.0,0.0,work,home,16:30:00,1,16:37:43,1,59400,59863,0 days 00:07:43,463.0,10300.0
2,fatema,poor,0,yes,111.87873939522729,1,bike,0.0,0.0,10100.0,0.0,home,work,08:00:00,1,08:52:31,1,28800,31951,0 days 00:52:31,3151.0,13130.0
3,fatema,poor,0,yes,111.87873939522729,2,bike,10100.0,0.0,0.0,0.0,work,home,17:30:00,1,18:22:31,1,63000,66151,0 days 00:52:31,3151.0,13130.0
4,fred,poor,0,yes,113.01188458431385,1,bus,0.0,0.0,10100.0,0.0,home,work,08:00:00,1,08:46:18,1,28800,31578,0 days 00:46:18,2778.0,10230.0
5,fred,poor,0,yes,113.01188458431385,2,bus,10100.0,0.0,0.0,0.0,work,home,17:30:00,1,17:46:18,1,63000,63978,0 days 00:16:18,978.0,10230.0
6,gerry,poor,0,yes,105.5293475373047,1,bus,0.0,0.0,10100.0,0.0,home,work,07:00:00,1,07:46:18,1,25200,27978,0 days 00:46:18,2778.0,10230.0
7,gerry,poor,0,yes,105.5293475373047,2,bus,10100.0,0.0,0.0,0.0,work,home,16:30:00,1,17:46:18,1,59400,63978,0 days 01:16:18,4578.0,10230.0
8,nick,poor,0,yes,129.592238766919,1,car,0.0,0.0,0.0,10000.0,home,work,08:00:00,1,08:00:04,1,28800,28804,0 days 00:00:04,4.0,10100.0
9,nick,poor,0,yes,129.592238766919,2,car,0.0,10000.0,0.0,0.0,work,home,17:30:00,1,17:37:34,1,63000,63454,0 days 00:07:34,454.0,10100.0
```